### PR TITLE
修改了5个文件的代码

### DIFF
--- a/entropy_model.py
+++ b/entropy_model.py
@@ -243,7 +243,6 @@ class EntropyBottleneck(EntropyBase):
         values = torchac.decode_float_cdf(out_cdf, strings)
         values = values.float()
         values += minima
-
         return values
 
 

--- a/entropy_model.py
+++ b/entropy_model.py
@@ -496,3 +496,4 @@ class GaussianConditional(EntropyBase):
             values = values.to(dequantize_dtype)
             values += minima
             return values
+

--- a/entropy_model.py
+++ b/entropy_model.py
@@ -1,4 +1,4 @@
-#熵模型
+# 熵模型
 import torch
 import torch.nn as nn
 from torch.nn.parameter import Parameter
@@ -18,11 +18,12 @@ os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 
-#覆写自动求导的类实现反传梯度为1
+# 覆写自动求导的类实现反传梯度为1
 class RoundNoGradient(torch.autograd.Function):
     """
     Another implementaion in compressai:
         return torch.round(x) - x.detach() + x """
+
     @staticmethod
     def forward(ctx, x):
         return x.round()
@@ -31,39 +32,42 @@ class RoundNoGradient(torch.autograd.Function):
     def backward(ctx, g):
         return g
 
-#覆写自动求导类实现对x的下界约束
+
+# 覆写自动求导类实现对x的下界约束
 class Low_bound(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x,lower_bound=1e-9):
+    def forward(ctx, x, lower_bound=1e-9):
         ctx.save_for_backward(x)
         x = torch.clamp(x, min=lower_bound)
         return x
 
     @staticmethod
-    def backward(ctx, g,lower_bound=1e-9):
+    def backward(ctx, g, lower_bound=1e-9):
         x, = ctx.saved_tensors
         grad1 = g.clone()
         try:
-            grad1[x<lower_bound] = 0
+            grad1[x < lower_bound] = 0
         except RuntimeError:
-            print("ERROR! grad1[x<%.3e] = 0"%lower_bound)
+            print("ERROR! grad1[x<%.3e] = 0" % lower_bound)
             grad1 = g.clone()
-        pass_through_if = np.logical_or(x.cpu().detach().numpy() >= lower_bound, g.cpu().detach().numpy()<0.0)
-        t = torch.Tensor(pass_through_if+0.0).to(grad1.device)
+        pass_through_if = np.logical_or(x.cpu().detach().numpy() >= lower_bound, g.cpu().detach().numpy() < 0.0)
+        t = torch.Tensor(pass_through_if + 0.0).to(grad1.device)
 
-        return grad1*t,None
+        return grad1 * t, None
+
 
 class EntropyBase(nn.Module):
     """实现熵编码共有的方法, 避免造轮子"""
+
     def __init__(self):
         super().__init__()
-    
-    def quantize(self,inputs,mode,means=None):
-        if mode not in ("noise","quantize","symbols"):
+
+    def quantize(self, inputs, mode, means=None):
+        if mode not in ("noise", "quantize", "symbols"):
             raise ValueError(f"Invalid quantization mode: ", mode)
         # noise
         if mode == "noise":
-            noise = torch.empty_like(inputs).uniform_(-0.5,0.5)
+            noise = torch.empty_like(inputs).uniform_(-0.5, 0.5)
             return inputs + noise
         # quantize: return  round(x - means) + means
         outputs = inputs.clone()  # Deep copy
@@ -79,14 +83,14 @@ class EntropyBase(nn.Module):
         outputs = outputs.int()
         return outputs
 
-    def dequantize(self,inputs,means,dtype=torch.float):
+    def dequantize(self, inputs, means, dtype=torch.float):
         if means is not None:
             outputs = inputs.type_as(means)
             outputs += means
         else:
             outputs = inputs.type(dtype)
         return outputs
-    
+
 
 class EntropyBottleneck(EntropyBase):
     """The layer implements a flexible probability density model to estimate
@@ -94,8 +98,8 @@ class EntropyBottleneck(EntropyBase):
     >"Variational image compression with a scale hyperprior"
     > J. Balle, D. Minnen, S. Singh, S. J. Hwang, N. Johnston
     > https://arxiv.org/abs/1802.01436"""
-    
-    def __init__(self, channels, init_scale=8, filters=(3,3,3,3)):
+
+    def __init__(self, channels, init_scale=8, filters=(3, 3, 3, 3)):
         """create parameters.
         """
         super(EntropyBottleneck, self).__init__()
@@ -108,7 +112,7 @@ class EntropyBottleneck(EntropyBase):
         filters = (1,) + self._filters + (1,)
         scale = self._init_scale ** (1 / (len(self._filters) + 1))
         # 使用parameterlist在多卡训练时会报错：
-        # UserWarning: nn.ParameterList is being used with DataParallel but this is not supported. 
+        # UserWarning: nn.ParameterList is being used with DataParallel but this is not supported.
         # This list will appear empty for the models replicated on each GPU except the original one.
         # # Create variables.
         # self._matrices = nn.ParameterList([])
@@ -117,23 +121,23 @@ class EntropyBottleneck(EntropyBase):
 
         for i in range(len(self._filters) + 1):
             #
-            matrix = torch.Tensor(channels, filters[i+1], filters[i])
+            matrix = torch.Tensor(channels, filters[i + 1], filters[i])
             init_matrix = np.log(np.expm1(1.0 / scale / filters[i + 1]))
             matrix.data.fill_(init_matrix)
             self.register_parameter(f"_matrix{i:d}", Parameter(matrix))
             #
-            bias = torch.Tensor(channels, filters[i+1], 1)
+            bias = torch.Tensor(channels, filters[i + 1], 1)
             nn.init.uniform_(bias, -0.5, 0.5)
             self.register_parameter(f"_bias{i:d}", Parameter(bias))
-            # 
-            if i < len(self._filters):    
-                factor = torch.Tensor(channels, filters[i+1], 1)
+            #
+            if i < len(self._filters):
+                factor = torch.Tensor(channels, filters[i + 1], 1)
                 factor.data.fill_(0.0)
                 self.register_parameter(f"_factor{i:d}", nn.Parameter(factor))
 
     def _logits_cumulative(self, inputs):
         """Evaluate logits of the cumulative densities.
-        
+
         Arguments:
         inputs: The values at which to evaluate the cumulative densities,
             expected to have shape `(channels, 1, batch*H*W)`.
@@ -156,7 +160,7 @@ class EntropyBottleneck(EntropyBase):
         return logits
 
     def _likelihood(self, inputs):
-        #Input:[channels, 1, points] Output:[channels, 1, points]
+        # Input:[channels, 1, points] Output:[channels, 1, points]
         lower = self._logits_cumulative(inputs - 0.5)
         upper = self._logits_cumulative(inputs + 0.5)
         sign = -torch.sign(torch.add(lower, upper)).detach()
@@ -164,76 +168,75 @@ class EntropyBottleneck(EntropyBase):
         return likelihood
 
     def forward(self, inputs, quantize_mode="noise"):
-        #Input:[B,C,H,W] --> [C, 1, B*H*W] -->Output:[B,C,H,W]
-        #维度转换
+        # Input:[B,C,H,W] --> [C, 1, B*H*W] -->Output:[B,C,H,W]
+        # 维度转换
         perm = np.arange(len(inputs.shape))
         perm[0], perm[1] = perm[1], perm[0]
         inv_perm = np.arange(len(inputs.shape))[np.argsort(perm)]
         inputs = inputs.permute(*perm).contiguous()
         shape = inputs.size()
         inputs = inputs.reshape(inputs.size(0), 1, -1)
-        #量化
-        if quantize_mode is None: 
+        # 量化
+        if quantize_mode is None:
             outputs = inputs
-        else: 
+        else:
             outputs = self.quantize(inputs, mode=quantize_mode)
-        
+
         likelihood = self._likelihood(outputs)
         likelihood = Low_bound.apply(likelihood)
-        #转化为输入维度
+        # 转化为输入维度
         outputs = outputs.reshape(shape)
         outputs = outputs.permute(*inv_perm).contiguous()
-
         likelihood = likelihood.reshape(shape)
         likelihood = likelihood.permute(*inv_perm).contiguous()
         return outputs, likelihood
 
-    #将概率转换为累积概率
+    # 将概率转换为累积概率
     def _pmf_to_cdf(self, pmf):
         cdf = pmf.cumsum(dim=-1)
-        #第一维添加0，最后一维变成1
-        spatial_dimensions = pmf.shape[:-1]+(1,)
+        # 第一维添加0，最后一维变成1
+        spatial_dimensions = pmf.shape[:-1] + (1,)
         zeros = torch.zeros(spatial_dimensions, dtype=pmf.dtype, device=pmf.device)
-        #cdf第一个元素设置为0
+        # cdf第一个元素设置为0
         cdf_with_0 = torch.cat([zeros, cdf], dim=-1)
         cdf_max_1 = torch.clamp(cdf_with_0, max=1.)
         return cdf_max_1
 
     @torch.no_grad()
-    def compress(self, inputs, device='cpu'):
-        #Input:[B,C,H,W]
-        #量化
+    def compress(self, inputs, device='cuda'):
+        # Input:[B,C,H,W]
+        # 量化
         values = self.quantize(inputs, mode="symbols")
         batch_size, channels, H, W = values.shape[:]
-        #获得编码范围内所有字符的概率值
+        # 获得编码范围内所有字符的概率值
         minima = values.min().detach().float()
         maxima = values.max().detach().float()
-        symbols = torch.arange(minima, maxima+1)
+        symbols = torch.arange(minima, maxima + 1)
         # 对编码元素做一个偏移，从0开始
-        values_norm = (values-minima).to(torch.int16)
-        minima, maxima = torch.tensor([minima]), torch.tensor([maxima])  #将minima和maxima重新封装为tensor
-        
-        #[channels, 1, points],points为编码值范围
-        symbols = symbols.reshape(1, 1, -1).repeat(channels, 1, 1)#.to(device)
+        values_norm = (values - minima).to(torch.int16)
+        minima, maxima = torch.tensor([minima]), torch.tensor([maxima])  # 将minima和maxima重新封装为tensor
+
+        # [channels, 1, points],points为编码值范围
+        symbols = symbols.reshape(1, 1, -1).repeat(channels, 1, 1).to(device)
         print(f'entropybottleneck encode device: {symbols.device}')
         pmf = self._likelihood(symbols)
         pmf = torch.clamp(pmf, min=self._likelihood_bound)
         cdf = self._pmf_to_cdf(pmf)
         cdf_expand = cdf.unsqueeze(0).unsqueeze(2)
-        out_cdf = cdf_expand.repeat(batch_size, 1, H, W, 1).to('cpu')#.cpu()
-        values_norm = values_norm.to('cpu')#.cpu() # torchac需要传入元素在CPU上
-        #torchac传入两个主要参数，概率表和待编码元素，概率表out_cdf是按顺序排列的概率，格式[B,C,H,W,point]，待编码元素格式[B,C,H,W]
+        out_cdf = cdf_expand.repeat(batch_size, 1, H, W, 1).to('cpu')
+        values_norm = values_norm.to('cpu')  # .cpu() # torchac需要传入元素在CPU上
+        # torchac传入两个主要参数，概率表和待编码元素，概率表out_cdf是按顺序排列的概率，格式[B,C,H,W,point]，待编码元素格式[B,C,H,W]
         strings = torchac.encode_float_cdf(out_cdf, values_norm)
         return strings, minima.cpu().numpy(), maxima.cpu().numpy()
 
     @torch.no_grad()
-    def decompress(self, strings, minima, maxima, shape):
+    def decompress(self, strings, minima, maxima, shape, device='cuda'):
         batch_size, channels, H, W = shape[:]
-        symbols = torch.arange(int(minima), int(maxima+1))#类型转换numpy.int32->int32
-        symbols = symbols.reshape(1, 1, -1).repeat(channels, 1, 1).to('cpu')
+        symbols = torch.arange(int(minima), int(maxima + 1))  # 类型转换numpy.int32->int32
+        symbols = symbols.reshape(1, 1, -1).repeat(channels, 1, 1).to(device)
         print(f'entropybottleneck decode device: {symbols.device}')
         pmf = self._likelihood(symbols)
-        pmf = torch.clamp(pmf, min=self._likelihood_bound).cpu()
+        pmf = torch.clamp(pmf, min=self._likelihood_bound)
 
         cdf = self._pmf_to_cdf(pmf)
         out_cdf = cdf.unsqueeze(0).unsqueeze(2).repeat(batch_size, 1, H, W, 1).cpu()
@@ -249,11 +252,12 @@ class GaussianConditional(EntropyBase):
     在设计思想上和EntropyBottleneck并无大的差别,这里假设y_hat能够较好的满足高斯独立分布,
     因此使用高斯正态分布表示CDF
     """
-    def __init__(self,scale_table,scale_bound=0.11,tail_mass=1e-9,entropy_coder="torchac"):
-        super(GaussianConditional,self).__init__()
+
+    def __init__(self, scale_table, scale_bound=0.11, tail_mass=1e-9, entropy_coder="torchac"):
+        super(GaussianConditional, self).__init__()
         # 检查scale_table是否规范
         if scale_table and (
-            scale_table !=sorted(scale_table) or any(s <=0 for s in scale_table)
+                scale_table != sorted(scale_table) or any(s <= 0 for s in scale_table)
         ):
             raise ValueError(f"Invalid scale_table: '({scale_table})'")
         # 保存scal_table
@@ -271,39 +275,39 @@ class GaussianConditional(EntropyBase):
         # other
         self.tail_mass = tail_mass  # -infinite,[tail_mass/2],PMF or CDF,[tail_mass/2],+infinite
         assert self.tail_mass < 0.5
-        self.entropy_coder = entropy_coder # 默认熵编码器是torchac, 在compressai中是内置的ans, 两者是否存在差异
+        self.entropy_coder = entropy_coder  # 默认熵编码器是torchac, 在compressai中是内置的ans, 两者是否存在差异
         self._likelihood_bound = 1e-9
 
-    def forward(self,inputs,scales, means=0):
+    def forward(self, inputs, scales, means=0):
         # 1. 量化（加噪声）
-        outputs = self.quantize(inputs,mode="noise", means=means)
+        outputs = self.quantize(inputs, mode="noise", means=means)
         # 2. 计算似然,并保证似然大于1e-9(lower bound)
-        likelihood = self._likelihood(outputs,scales, means)
+        likelihood = self._likelihood(outputs, scales, means)
         likelihood = Low_bound.apply(likelihood)
-        return outputs,likelihood    
-                      
-    def _standardized_cumulative(self,inputs):
+        return outputs, likelihood
+
+    def _standardized_cumulative(self, inputs):
         # 正态分布的累积分布函数
         half = float(0.5)
-        const = float(-(2**-0.5))
+        const = float(-(2 ** -0.5))
         # 这里就是利用erfc的形式来计算高斯分布累积分布，整理后得到：1/2-F(x)
         return half * torch.erfc(const * inputs)
 
-    def _likelihood(self, inputs, scales, means=0):
+    def _likelihood(self, inputs, scales, means=None):
         # 实际编码时:inputs.size [B,C,H,W,points] scales.size(B,C,H,W,1) means.size(B,C,H,W,1) likelihood.size(B,C,H,W,points)
-        scales = Low_bound.apply(scales,0.11) 
+        scales = Low_bound.apply(scales, 0.11)
         values = inputs
         if means is not None:
-            values = inputs-means
+            values = inputs - means
         else:
             values = inputs
         values = torch.abs(values)
         # 将普通的高斯分布归一化到正态分布
-        upper = self._standardized_cumulative((0.5 - values)/scales)
-        lower = self._standardized_cumulative((-0.5 - values)/scales)
+        upper = self._standardized_cumulative((0.5 - values) / scales)
+        lower = self._standardized_cumulative((-0.5 - values) / scales)
         likelihood = upper - lower
         return likelihood
-    
+
     def update(self):
         """更新CDF"""
         multiplier = - self._standardized_quantile(self.tail_mass / 2)
@@ -312,49 +316,49 @@ class GaussianConditional(EntropyBase):
         max_length = torch.max(pmf_length).item()
 
         device = pmf_center.device
-        samples = torch.abs(torch.arange(max_length,device=device)).float()
+        samples = torch.abs(torch.arange(max_length, device=device)).float()
         samples_scale = self.scale_table.unsqueeze(1).float()  # (2,4,5,..) -> ((2),(4),(5),...)
-        upper = self._standardized_cumulative((-samples + 0.5)/samples_scale)  
+        upper = self._standardized_cumulative((-samples + 0.5) / samples_scale)
         # samples = (0,1,2,3,4....), 和samples_scale维度不一致
-        # 但是, 根据pytorch张量运算的广播机制, samples/samples_scale 最终得到 
+        # 但是, 根据pytorch张量运算的广播机制, samples/samples_scale 最终得到
         # ( ( 0/2, 1/2, 2/2, 3/2, ...),
         #   ( 0/4, 1/4, 2/4, 3/4, ...),
         #   ( 0/5, 1/5, 2/5, 3/5, ...),
         #   ...)
-        lower = self._standardized_cumulative((-samples - 0.5)/samples_scale) # e.g.  tensor([0.4602, 0.3821, 0.3085, 0.2420],[...],...)
+        lower = self._standardized_cumulative(
+            (-samples - 0.5) / samples_scale)  # e.g.  tensor([0.4602, 0.3821, 0.3085, 0.2420],[...],...)
         pmf = upper - lower
 
         # 根据实际分布更新tail_mass
         # TODO: check
-        tail_mass = 2 * lower[:,:1] #  compressai
-        tail_mass = 2 * lower[:,-1:]  # corrected version
+        tail_mass = 2 * lower[:, :1]  # compressai
+        tail_mass = 2 * lower[:, -1:]  # corrected version
 
-        quantized_cdf = torch.Tensor(len(pmf_length),max_length + 2) 
-        quantized_cdf = self._pmf_to_cdf(pmf,tail_mass,pmf_length,max_length)
-        self._quantized_cdf = quantized_cdf # 量化后的CDF + tail_mass + entropy_coder_precision
-        self._offset = - pmf_center # tail_mass所对应的变量值，即cdf开始计数的变量值 
-        self._cdf_length = pmf_length + 2 # 每个通道的CDF长度，多出的两个变量是 tail_mass + entropy_coder_precision
-    
+        quantized_cdf = torch.Tensor(len(pmf_length), max_length + 2)
+        quantized_cdf = self._pmf_to_cdf(pmf, tail_mass, pmf_length, max_length)
+        self._quantized_cdf = quantized_cdf  # 量化后的CDF + tail_mass + entropy_coder_precision
+        self._offset = - pmf_center  # tail_mass所对应的变量值，即cdf开始计数的变量值
+        self._cdf_length = pmf_length + 2  # 每个通道的CDF长度，多出的两个变量是 tail_mass + entropy_coder_precision
+
     @staticmethod
     def _standardized_quantile(quantile):
         return scipy.stats.norm.ppf(quantile)
 
     def _standardized_cumulative(self, inputs):
         half = float(0.5)
-        const = float(-(2**-0.5))
+        const = float(-(2 ** -0.5))
         # Using the complementary error function maximizes numerical precision.
         return half * torch.erfc(const * inputs)
 
-    #将概率转换为累积概率
+    # 将概率转换为累积概率
     def _pmf_to_cdf(self, pmf):
-        l = pmf.shape[-1]
         cdf = pmf.cumsum(dim=-1)
-        #第一维添加0，最后一维变成1
-        spatial_dimensions = pmf.shape[:-1]+(1,)
+        # 第一维添加0，最后一维变成1
+        spatial_dimensions = pmf.shape[:-1] + (1,)
         zeros = torch.zeros(spatial_dimensions, dtype=pmf.dtype, device=pmf.device)
-        #cdf第一个元素设置为0
+        # cdf第一个元素设置为0
         cdf_with_0 = torch.cat([zeros, cdf], dim=-1)
-        #cdf最大值即最后一个值设置为1
+        # cdf最大值即最后一个值设置为1
         # cdf_with_0[:, :, :, :, l].fill_(1.)
         cdf_max_1 = torch.clamp(cdf_with_0, max=1.)
         return cdf_max_1
@@ -392,102 +396,98 @@ class GaussianConditional(EntropyBase):
                 self._offset.reshape(-1).int().tolist(),
             )
         return strings
-    
+
     def _check_cdf_size(self):
         if self._quantized_cdf.numel() == 0:
             raise ValueError('Uninitialized CDFs. Run update() First' )
-    
+
     def _check_cdf_length(self):
         if self._cdf_length.numel() == 0:
             raise ValueError("Unitialized CDF lengths. Run update() First.")
         if len(self._cdf_length.size()) != 1:
             raise ValueError(f"Invalid offsets size {self._cdf_length.size()}")
-    
+
     def _check_offsets_size(self):
         if self._offset.numel() == 0:
             raise ValueError("Unintialized offsets. Run update() firstly.")
     """
+
     @torch.no_grad()
-    def compress(self,inputs,scales, means=None, minima=None, maxima=None, model_name='JointAutoregressive', encoder=None):
+    def compress(self, inputs, scales, means=None, minima=None, maxima=None, model_name='JointAutoregressive',
+                 encoder=None):
         """new version
-        return: strings, minima, maxima 
+        return: strings, minima, maxima
         """
         if model_name == 'JointAutoregressive':
             device = 'cpu'
         else:
             device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         # 量化
-        values = self.quantize(inputs,mode="symbols")
-        batch_size, channels,H,W = values.shape
-        #获得编码范围内所有字符的概率值，如果给定了就不用统计了
+        values = self.quantize(inputs, mode="symbols")
+        batch_size, channels, H, W = values.shape
+        # 获得编码范围内所有字符的概率值，如果给定了就不用统计了
         # if minima == None and maxima == None:
         #     minima = values.min().detach().float()
         #     maxima = values.max().detach().float()
         #     minima, maxima = torch.int([minima]), torch.int([maxima])
         minima = values.min().detach().float()
         maxima = values.max().detach().float()
-        symbols = torch.arange(minima, maxima+1).to(device)
+        symbols = torch.arange(minima, maxima + 1).to(device)
         # 对编码元素做一个偏移，使其最小值为0
-        values = (values-minima).to(torch.int16)
-        minima, maxima = torch.tensor([minima]), torch.tensor([maxima])
+        values = (values - minima).to(torch.int16)
         # symbols: torch.Size([points]) -> torch.Size([1, 1, 1, 1, points]) -> (batch_size,C,H,W,points)
         # scales: torch.Size([batch_size, C, H, W])  -> (batch_size, C,H,W,1)，对应unsqueeze(-1)操作
-        symbols = symbols.reshape(1, 1, 1, 1, -1).repeat(batch_size,channels, H, W, 1).to(device)
+        symbols = symbols.reshape(1, 1, 1, 1, -1).repeat(batch_size, channels, H, W, 1).to(device)
         scales = scales.to(device)
-        if means is not None: means = means.to(device)
-        # assert symbols.device == scales.device and symbols.device == means.device
-        if means is not None: pmf = self._likelihood(symbols,scales.unsqueeze(-1), means=means.unsqueeze(-1))
-        else: pmf = self._likelihood(symbols,scales.unsqueeze(-1))
+        pmf = self._likelihood(symbols, scales.unsqueeze(-1), means=means.unsqueeze(-1))
         pmf = torch.clamp(pmf, min=self._likelihood_bound)
-        #pmf = F.softmax(pmf, dim=4)
+        # pmf = F.softmax(pmf, dim=4)
         if model_name == 'JointAutoregressive':
-        # 对于自回归模型使用range-coder编码器编解码，每次编码张量格式为[1, C, 1, 1]
+            # 对于自回归模型使用range-coder编码器编解码，每次编码张量格式为[1, C, 1, 1]
             assert encoder is not None
             resolution = 1e+5
             values = values.squeeze(3).squeeze(2).squeeze(0).cpu()
             cdf = self._pmf_to_cdf(pmf).squeeze(3).squeeze(2).squeeze(0).cpu()
-            cdf = torch.round(cdf*resolution).int()
-            start_time = time.time()
+            cdf = torch.round(cdf * resolution).int()
             for i in range(values.size(0)):
                 seq_list = []
                 seq_list.append(int(values[i]))
                 cdf_list = cdf[i].tolist()
                 encoder.encode(seq_list, cdf_list)
-            # print('Time0:\t', round(time.time() - start_time, 3), 's')
         else:
-        # 对于hyper模型使用常规的torchac编码器编解码
+            # 对于hyper模型使用常规的torchac编码器编解码
             cdf = self._pmf_to_cdf(pmf).to('cpu')
             values = values.to('cpu')
-            #torchac传入两个主要参数，概率表和待编码元素，概率表out_cdf是按顺序排列的概率，格式[B,C,H,W,point]，待编码元素格式[B,C,H,W]
+            # torchac传入两个主要参数，概率表和待编码元素，概率表out_cdf是按顺序排列的概率，格式[B,C,H,W,point]，待编码元素格式[B,C,H,W]
             strings = torchac.encode_float_cdf(cdf, values)
             return strings, minima.cpu().numpy(), maxima.cpu().numpy()
 
     @torch.no_grad()
-    def decompress(self, strings, minima, maxima, shape,scales, means=None, dequantize_dtype=torch.float, model_name='JointAutoregressive', decoder=None):
+    def decompress(self, strings, minima, maxima, shape, scales, means=None, dequantize_dtype=torch.float,
+                   model_name='JointAutoregressive', decoder=None):
         """new version
         return: features
         """
         if model_name == 'JointAutoregressive':
-            device = 'cpu'    
+            device = 'cpu'
         else:
             device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         batch_size, channels, H, W = shape[:]
-        symbols = torch.arange(minima, maxima+1).to(device)
-        symbols = symbols.reshape(1, 1, 1, 1, -1).repeat(batch_size,channels, H, W, 1)
+        symbols = torch.arange(minima, maxima + 1).to(device)
+        symbols = symbols.reshape(1, 1, 1, 1, -1).repeat(batch_size, channels, H, W, 1)
 
-        if means != None: pmf = self._likelihood(symbols,scales.unsqueeze(-1), means.unsqueeze(-1))
-        else: pmf = self._likelihood(symbols,scales.unsqueeze(-1))
+        pmf = self._likelihood(symbols, scales.unsqueeze(-1), means.unsqueeze(-1))
         pmf = torch.clamp(pmf, min=self._likelihood_bound)
-        #pmf = F.softmax(pmf, dim=4)
+        # pmf = F.softmax(pmf, dim=4)
         if model_name == 'JointAutoregressive':
             assert decoder is not None
             seq_list = []
             resolution = 1e+5
             cdf = self._pmf_to_cdf(pmf).squeeze(3).squeeze(2).squeeze(0).cpu()
-            cdf = torch.round(cdf*resolution).int()
+            cdf = torch.round(cdf * resolution).int()
             for i in range(channels):
                 cdf_list = cdf[i].tolist()
-                values = decoder.decode(1, cdf_list)[0]+minima
+                values = decoder.decode(1, cdf_list)[0] + minima
                 seq_list.append(values)
             # 返回Tensor shape:[1, M]
             return torch.tensor(seq_list).unsqueeze(0)

--- a/model.py
+++ b/model.py
@@ -825,7 +825,6 @@ class CheckerboardAutogressive(JointAutoregressiveHierarchicalPriors):
             z_len_minima = np.frombuffer(fin.read(1), dtype=np.int8)[0]
             z_minima = np.frombuffer(fin.read(4 * z_len_minima), dtype=np.float32)[0]
             z_maxima = np.frombuffer(fin.read(4 * z_len_minima), dtype=np.float32)[0]
-
             y_shape = np.frombuffer(fin.read(4 * 4), dtype=np.int32)
             y_len_minima = np.frombuffer(fin.read(1), dtype=np.int8)[0]
             an_minima = np.frombuffer(fin.read(4 * y_len_minima), dtype=np.float32)[0]

--- a/model.py
+++ b/model.py
@@ -554,13 +554,6 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
             y_len_minima = np.frombuffer(fin.read(2), dtype=np.int16)[0]
             y_minima = np.frombuffer(fin.read(2 * y_len_minima), dtype=np.int16)
             y_maxima = np.frombuffer(fin.read(2 * y_len_minima), dtype=np.int16)
-            # print(f'z_shape: {z_shape}')
-            # print(f'z_len_minima: {z_len_minima}')
-            # print(f'z_minima: {z_minima}')
-            # print(f'z_maxima: {z_maxima}')
-            # print(f'y_len_minima: {y_len_minima}')
-            # print(f'y_minima: {y_minima}')
-            # print(f'y_maxima: {y_maxima}')
             y_file_name = file_name + postfix + '_Fy.bin'
             with open(y_file_name, 'rb'):
                 pass

--- a/model.py
+++ b/model.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np
-#from zmq import device
+# from zmq import device
 from gdn import GDN, GDN1
 from entropy_model import EntropyBottleneck, GaussianConditional
 from torch import Tensor
@@ -17,75 +17,73 @@ os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
+
 class Factorized(nn.Module):
     def __init__(self, N=128, M=192):
         super().__init__()
         self.entropy_bottleneck = EntropyBottleneck(M)
         self.g_a = nn.Sequential(
-            nn.Conv2d(3,N,stride=2,kernel_size=5,padding=2),
+            nn.Conv2d(3, N, stride=2, kernel_size=5, padding=2),
             GDN(N),
-            nn.Conv2d(N,N,stride=2,kernel_size=5,padding=2),
+            nn.Conv2d(N, N, stride=2, kernel_size=5, padding=2),
             GDN(N),
-            nn.Conv2d(N,N,stride=2,kernel_size=5,padding=2),
+            nn.Conv2d(N, N, stride=2, kernel_size=5, padding=2),
             GDN(N),
-            nn.Conv2d(N,M,kernel_size=5,stride=2,padding=2),
+            nn.Conv2d(N, M, kernel_size=5, stride=2, padding=2),
         )
 
         self.g_s = nn.Sequential(
-            nn.ConvTranspose2d(M,N,kernel_size=5,padding=2,output_padding=1,stride=2),
+            nn.ConvTranspose2d(M, N, kernel_size=5, padding=2, output_padding=1, stride=2),
             GDN(N, inverse=True),
-            nn.ConvTranspose2d(N,N,kernel_size=5,padding=2,output_padding=1,stride=2),
+            nn.ConvTranspose2d(N, N, kernel_size=5, padding=2, output_padding=1, stride=2),
             GDN(N, inverse=True),
-            nn.ConvTranspose2d(N,N,kernel_size=5,padding=2,output_padding=1,stride=2),
+            nn.ConvTranspose2d(N, N, kernel_size=5, padding=2, output_padding=1, stride=2),
             GDN(N, inverse=True),
-            nn.ConvTranspose2d(N,3,kernel_size=5,stride=2,output_padding=1,padding=2),
+            nn.ConvTranspose2d(N, 3, kernel_size=5, stride=2, output_padding=1, padding=2),
         )
-        
+
     def forward(self, x):
-       y = self.g_a(x)
-       y_hat, y_likelihoods = self.entropy_bottleneck(y)
-       x_hat = self.g_s(y_hat)
-       return {'x_hat':x_hat, 'likelihood':y_likelihoods}
-    
+        y = self.g_a(x)
+        y_hat, y_likelihoods = self.entropy_bottleneck(y)
+        x_hat = self.g_s(y_hat)
+        return {'x_hat': x_hat, 'likelihood': y_likelihoods}
+
     def compress(self, x):
         y = self.g_a(x)
-        self.entropy_bottleneck.to('cpu')
-        y_strings,y_minima,y_maxima= self.entropy_bottleneck.compress(y)
-        return {"strings": y_strings, "shape": y.shape,"scope":[y_minima,y_maxima]}
+        y_strings, y_minima, y_maxima = self.entropy_bottleneck.compress(y)
+        return {"strings": y_strings, "shape": y.shape, "scope": [y_minima, y_maxima]}
 
-    def decompress(self, strings, minima,maxima,shape):
+    def decompress(self, strings, minima, maxima, shape):
         y_hat = self.entropy_bottleneck.decompress(strings, minima, maxima, shape).to(device)
         x_hat = self.g_s(y_hat)
         return x_hat
 
-    def encode(self,inputs,file_name,postfix=''):
+    def encode(self, inputs, file_name, postfix=''):
         out = self.compress(inputs)
         strings = out['strings']
         shape = out['shape']
-        minima,maxima = out['scope']
-        
-        with open(file_name+postfix+'_F.bin', 'wb') as fout:
+        minima, maxima = out['scope']
+
+        with open(file_name + postfix + '_F.bin', 'wb') as fout:
             fout.write(strings)
 
-        with open(file_name+postfix+'_H.bin', 'wb') as fout:
+        with open(file_name + postfix + '_H.bin', 'wb') as fout:
             fout.write(np.array(shape, dtype=np.int32).tobytes())
             fout.write(np.array(len(minima), dtype=np.int8).tobytes())
-            #记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
+            # 记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
             fout.write(np.array(minima, dtype=np.float32).tobytes())
             fout.write(np.array(maxima, dtype=np.float32).tobytes())
 
-
-    def decode(self,filename,postfix=''):
-
-        with open(filename+postfix+'_F.bin', 'rb') as fin:
+    def decode(self, filename, postfix=''):
+        with open(filename + postfix + '_F.bin', 'rb') as fin:
             strings = fin.read()
-        with open(filename+postfix+'_H.bin', 'rb') as fin:
-            shape = np.frombuffer(fin.read(4*4), dtype=np.int32)
+        with open(filename + postfix + '_H.bin', 'rb') as fin:
+            shape = np.frombuffer(fin.read(4 * 4), dtype=np.int32)
             len_minima = np.frombuffer(fin.read(1), dtype=np.int8)[0]
-            minima = np.frombuffer(fin.read(4*len_minima), dtype=np.float32)[0]
-            maxima = np.frombuffer(fin.read(4*len_minima), dtype=np.float32)[0]
+            minima = np.frombuffer(fin.read(4 * len_minima), dtype=np.float32)[0]
+            maxima = np.frombuffer(fin.read(4 * len_minima), dtype=np.float32)[0]
 
-        x_hat = self.decompress(strings,minima,maxima,shape)
+        x_hat = self.decompress(strings, minima, maxima, shape)
         return x_hat
 
 
@@ -94,146 +92,144 @@ class Hyperprior(nn.Module):
     hyperprior版本编解码器网络结构部分, 主要是g_a,g_s,h_a,h_s四种变换，以及forward
     参考CompressAI-master/compressai/models/google.py
     """
-    def __init__(self,entropy_bottleneck_channels=128,M=192,init_weights=None):
+
+    def __init__(self, entropy_bottleneck_channels=128, M=192, init_weights=None):
         super().__init__()
-        self.entropy_bottleneck=EntropyBottleneck(entropy_bottleneck_channels)
+        self.entropy_bottleneck = EntropyBottleneck(entropy_bottleneck_channels)
 
-        N=entropy_bottleneck_channels
-        #M:last layer of the encoder and last layer of the hyperprior decoder
+        N = entropy_bottleneck_channels
+        # M:last layer of the encoder and last layer of the hyperprior decoder
 
-        self.g_a=nn.Sequential(
-            #in_channels=3,out_channels=N,kernel_size=5,stride=2,padding=kernel_size//2
-            nn.Conv2d(3,N,kernel_size=5,stride=2,padding=2),
+        self.g_a = nn.Sequential(
+            # in_channels=3,out_channels=N,kernel_size=5,stride=2,padding=kernel_size//2
+            nn.Conv2d(3, N, kernel_size=5, stride=2, padding=2),
             GDN(N),
-            nn.Conv2d(N,N,kernel_size=5,stride=2,padding=2),
+            nn.Conv2d(N, N, kernel_size=5, stride=2, padding=2),
             GDN(N),
-            nn.Conv2d(N,N,kernel_size=5,stride=2,padding=2),
+            nn.Conv2d(N, N, kernel_size=5, stride=2, padding=2),
             GDN(N),
-            nn.Conv2d(N,M,kernel_size=5,stride=2,padding=2),
+            nn.Conv2d(N, M, kernel_size=5, stride=2, padding=2),
         )
 
-        self.g_s=nn.Sequential(
-            #in_channels=M,out_channels=N,kernel_size=5,stride=2,output_padding=stride-1,padding=kernel_size//2
-            nn.ConvTranspose2d(M,N,kernel_size=5,stride=2,output_padding=1,padding=2),
+        self.g_s = nn.Sequential(
+            # in_channels=M,out_channels=N,kernel_size=5,stride=2,output_padding=stride-1,padding=kernel_size//2
+            nn.ConvTranspose2d(M, N, kernel_size=5, stride=2, output_padding=1, padding=2),
             GDN(N, inverse=True),
-            nn.ConvTranspose2d(N,N,kernel_size=5,stride=2,output_padding=1,padding=2),
+            nn.ConvTranspose2d(N, N, kernel_size=5, stride=2, output_padding=1, padding=2),
             GDN(N, inverse=True),
-            nn.ConvTranspose2d(N,N,kernel_size=5,stride=2,output_padding=1,padding=2),
+            nn.ConvTranspose2d(N, N, kernel_size=5, stride=2, output_padding=1, padding=2),
             GDN(N, inverse=True),
-            nn.ConvTranspose2d(N,3,kernel_size=5,stride=2,output_padding=1,padding=2),
+            nn.ConvTranspose2d(N, 3, kernel_size=5, stride=2, output_padding=1, padding=2),
         )
 
-        self.h_a=nn.Sequential(
-            #in_channels=M,out_channels=N,kernel_size=3,stride=1,padding=kernel_size//2
-            nn.Conv2d(M,N,kernel_size=3,stride=1,padding=1),
+        self.h_a = nn.Sequential(
+            # in_channels=M,out_channels=N,kernel_size=3,stride=1,padding=kernel_size//2
+            nn.Conv2d(M, N, kernel_size=3, stride=1, padding=1),
             nn.ReLU(inplace=True),
-            nn.Conv2d(N,N,kernel_size=5,stride=2,padding=2),
+            nn.Conv2d(N, N, kernel_size=5, stride=2, padding=2),
             nn.ReLU(inplace=True),
-            nn.Conv2d(N,N,kernel_size=5,stride=2,padding=2),
+            nn.Conv2d(N, N, kernel_size=5, stride=2, padding=2),
         )
 
-        self.h_s=nn.Sequential(
-            nn.ConvTranspose2d(N,N,kernel_size=5,stride=2,output_padding=1,padding=2),
+        self.h_s = nn.Sequential(
+            nn.ConvTranspose2d(N, N, kernel_size=5, stride=2, output_padding=1, padding=2),
             nn.ReLU(inplace=True),
-            nn.ConvTranspose2d(N,N,kernel_size=5,stride=2,output_padding=1,padding=2),
+            nn.ConvTranspose2d(N, N, kernel_size=5, stride=2, output_padding=1, padding=2),
             nn.ReLU(inplace=True),
-            nn.Conv2d(N,M,kernel_size=3,stride=1,padding=1),
+            nn.Conv2d(N, M, kernel_size=3, stride=1, padding=1),
             nn.ReLU(inplace=True),
         )
 
         self.gaussian_conditional = GaussianConditional(None)
-    
-    @property
-    def downsampling_factor(self)->int:
-        return 2**(4+2)
-    
-    def forward(self,x):
-        y=self.g_a(x)
-        z=self.h_a(torch.abs(y))
-        z_hat,z_likelihood=self.entropy_bottleneck(z)
-        scales_hat=self.h_s(z_hat)
-        y_hat,y_likelihood=self.gaussian_conditional(y,scales_hat)
-        x_hat=self.g_s(y_hat)
 
-        return {"x_hat":x_hat, "likelihood":{"y":y_likelihood, "z":z_likelihood}}
-    
+    @property
+    def downsampling_factor(self) -> int:
+        return 2 ** (4 + 2)
+
+    def forward(self, x):
+        y = self.g_a(x)
+        z = self.h_a(torch.abs(y))
+        z_hat, z_likelihood = self.entropy_bottleneck(z)
+        scales_hat = self.h_s(z_hat)
+        y_hat, y_likelihood = self.gaussian_conditional(y, scales_hat)
+        x_hat = self.g_s(y_hat)
+
+        return {"x_hat": x_hat, "likelihood": {"y": y_likelihood, "z": z_likelihood}}
+
     @torch.no_grad()
     def compress(self, x):
         y = self.g_a(x)
         z = self.h_a(torch.abs(y))
-        self.entropy_bottleneck.cpu()
-        z_strings,z_minima,z_maxima = self.entropy_bottleneck.compress(z)
-        z_hat = self.entropy_bottleneck.decompress(z_strings, z_minima,z_maxima,z.shape).to(x.device)
+        z_strings, z_minima, z_maxima = self.entropy_bottleneck.compress(z)
+        z_hat = self.entropy_bottleneck.decompress(z_strings, z_minima, z_maxima, z.shape).to(x.device)
 
         scales_hat = self.h_s(z_hat)
-        self.gaussian_conditional.cpu()
-        y_strings,y_minima,y_maxima = self.gaussian_conditional.compress(y,scales_hat,model_name='Hyperprior')
-        return {"strings": [y_strings, z_strings], "shape":[y.shape,z.shape],"y_scope":[y_minima,y_maxima],"z_scope":[z_minima,z_maxima]}
+        y_strings, y_minima, y_maxima = self.gaussian_conditional.compress(y, scales_hat, model_name='Hyperprior')
+        return {"strings": [y_strings, z_strings], "shape": [y.shape, z.shape], "y_scope": [y_minima, y_maxima],
+                "z_scope": [z_minima, z_maxima]}
 
     @torch.no_grad()
-    def decompress(self, strings, shape, y_scope,z_scope):
+    def decompress(self, strings, shape, y_scope, z_scope):
         assert isinstance(strings, list) and len(strings) == 2
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        y_shape,z_shape = shape
+        y_shape, z_shape = shape
         y_minima, y_maxima = y_scope
         z_minima, z_maxima = z_scope
-        z_hat = self.entropy_bottleneck.decompress(strings[1], z_minima,z_maxima,z_shape).to(device)
+        z_hat = self.entropy_bottleneck.decompress(strings[1], z_minima, z_maxima, z_shape).to(device)
         scales_hat = self.h_s(z_hat)
-        y_hat = self.gaussian_conditional.decompress(strings[0],y_minima,y_maxima,y_shape,scales_hat, dequantize_dtype=z_hat.dtype,model_name='Hyperprior').to(device)
-        # print("y_hat shape ",y_hat.shape)
-        # print(y_shape)
+        y_hat = self.gaussian_conditional.decompress(strings[0], y_minima, y_maxima, y_shape, scales_hat,
+                                                     dequantize_dtype=z_hat.dtype, model_name='Hyperprior').to(device)
         x_hat = self.g_s(y_hat).clamp_(0, 1)
         return x_hat
 
-    def encode(self,inputs,file_name,postfix=''):
+    def encode(self, inputs, file_name, postfix=''):
         """
         在compress的基础上调用熵编码器进一步封装额外的参数
         """
         out = self.compress(inputs)
-        y_strings,z_strings = out['strings']
-        y_shape,z_shape = out['shape']
-        z_minima,z_maxima = out['z_scope']
-        y_minima,y_maxima = out['y_scope']
-        
-        with open(file_name+postfix+'_Fz.bin', 'wb') as fout:
+        y_strings, z_strings = out['strings']
+        y_shape, z_shape = out['shape']
+        z_minima, z_maxima = out['z_scope']
+        y_minima, y_maxima = out['y_scope']
+
+        with open(file_name + postfix + '_Fz.bin', 'wb') as fout:
             fout.write(z_strings)
-        with open(file_name+postfix+'_Fy.bin', 'wb') as fout:
+        with open(file_name + postfix + '_Fy.bin', 'wb') as fout:
             fout.write(y_strings)
 
-        with open(file_name+postfix+'_H.bin', 'wb') as fout:
+        with open(file_name + postfix + '_H.bin', 'wb') as fout:
             fout.write(np.array(z_shape, dtype=np.int32).tobytes())
             fout.write(np.array(len(z_minima), dtype=np.int8).tobytes())
-            #记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
+            # 记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
             fout.write(np.array(z_minima, dtype=np.float32).tobytes())
             fout.write(np.array(z_maxima, dtype=np.float32).tobytes())
 
             fout.write(np.array(y_shape, dtype=np.int32).tobytes())
             fout.write(np.array(len(y_minima), dtype=np.int8).tobytes())
-            #记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
+            # 记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
             fout.write(np.array(y_minima, dtype=np.float32).tobytes())
             fout.write(np.array(y_maxima, dtype=np.float32).tobytes())
 
-
-    def decode(self,file_name,postfix=''):
-
-        with open(file_name+postfix+'_Fz.bin', 'rb') as fin:
+    def decode(self, file_name, postfix=''):
+        with open(file_name + postfix + '_Fz.bin', 'rb') as fin:
             z_strings = fin.read()
-        with open(file_name+postfix+'_H.bin', 'rb') as fin:
-            z_shape = np.frombuffer(fin.read(4*4), dtype=np.int32)
+        with open(file_name + postfix + '_H.bin', 'rb') as fin:
+            z_shape = np.frombuffer(fin.read(4 * 4), dtype=np.int32)
             z_len_minima = np.frombuffer(fin.read(1), dtype=np.int8)[0]
-            z_minima = np.frombuffer(fin.read(4*z_len_minima), dtype=np.float32)[0]
-            z_maxima = np.frombuffer(fin.read(4*z_len_minima), dtype=np.float32)[0]
+            z_minima = np.frombuffer(fin.read(4 * z_len_minima), dtype=np.float32)[0]
+            z_maxima = np.frombuffer(fin.read(4 * z_len_minima), dtype=np.float32)[0]
 
-            y_shape = np.frombuffer(fin.read(4*4), dtype=np.int32)
+            y_shape = np.frombuffer(fin.read(4 * 4), dtype=np.int32)
             y_len_minima = np.frombuffer(fin.read(1), dtype=np.int8)[0]
-            y_minima = np.frombuffer(fin.read(4*y_len_minima), dtype=np.float32)[0]
-            y_maxima = np.frombuffer(fin.read(4*y_len_minima), dtype=np.float32)[0]
+            y_minima = np.frombuffer(fin.read(4 * y_len_minima), dtype=np.float32)[0]
+            y_maxima = np.frombuffer(fin.read(4 * y_len_minima), dtype=np.float32)[0]
 
-        with open(file_name+postfix+'_Fy.bin', 'rb') as fin:
+        with open(file_name + postfix + '_Fy.bin', 'rb') as fin:
             y_strings = fin.read()
 
-        x_hat = self.decompress([y_strings,z_strings],[y_shape,z_shape],[y_minima,y_maxima],[z_minima,z_maxima])
+        x_hat = self.decompress([y_strings, z_strings], [y_shape, z_shape], [y_minima, y_maxima], [z_minima, z_maxima])
         return x_hat
+
 
 class MaskedConv2d(nn.Conv2d):
     r"""Masked 2D convolution implementation, mask future "unseen" pixels.
@@ -254,9 +250,9 @@ class MaskedConv2d(nn.Conv2d):
         self.register_buffer("mask", torch.ones_like(self.weight.data))
         _, _, h, w = self.mask.size()
         # 当前行，中间开始后面所有列
-        self.mask[:, :, h // 2, w // 2 + (mask_type == "B") :] = 0
+        self.mask[:, :, h // 2, w // 2 + (mask_type == "B"):] = 0
         # 后面的所有行
-        self.mask[:, :, h // 2 + 1 :] = 0
+        self.mask[:, :, h // 2 + 1:] = 0
 
     def forward(self, x: Tensor) -> Tensor:
         self.weight.data *= self.mask
@@ -267,6 +263,7 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
     """
     HierarchicalPriors版本编解码器网络结构部分
     """
+
     def __init__(self, entropy_bottleneck_channels=192, M=192):
         # M:last layer of the encoder and last layer of the hyperprior decoder
         super().__init__()
@@ -307,17 +304,16 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
         self.h_s = nn.Sequential(
             nn.ConvTranspose2d(N, M, kernel_size=5, stride=2, output_padding=1, padding=2),
             nn.LeakyReLU(inplace=True),
-            nn.ConvTranspose2d(M, M * 3//2, kernel_size=5, stride=2, output_padding=1, padding=2),
+            nn.ConvTranspose2d(M, M * 3 // 2, kernel_size=5, stride=2, output_padding=1, padding=2),
             nn.LeakyReLU(inplace=True),
-            nn.Conv2d(M * 3//2, M * 2, kernel_size=3, stride=1, padding=1),
+            nn.Conv2d(M * 3 // 2, M * 2, kernel_size=3, stride=1, padding=1),
         )
 
-
-        self.context_prediction  = MaskedConv2d(
+        self.context_prediction = MaskedConv2d(
             M, 2 * M, kernel_size=5, padding=2, stride=1
         )
-        self.entropy_parameters  =nn.Sequential(
-            nn.Conv2d(M * 12//3, M * 10 // 3, kernel_size=1),
+        self.entropy_parameters = nn.Sequential(
+            nn.Conv2d(M * 12 // 3, M * 10 // 3, kernel_size=1),
             nn.LeakyReLU(inplace=True),
             nn.Conv2d(M * 10 // 3, M * 8 // 3, kernel_size=1),
             nn.LeakyReLU(inplace=True),
@@ -339,10 +335,10 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
         y_hat = self.gaussian_conditional.quantize(
             y, "noise" if self.training else "quantize"
         )
-        #上下文模型返回值
+        # 上下文模型返回值
         ctx_params = self.context_prediction(y_hat)
         # params.shape = ctx_params.shape = [B,2M,H,W]
-        #将上下文模型返回值与超先验层返回值送入熵模型
+        # 将上下文模型返回值与超先验层返回值送入熵模型
         # gaussian_params.shape=[B,2M,H,W]
         gaussian_params = self.entropy_parameters(
             torch.cat((params, ctx_params), dim=1)
@@ -358,23 +354,23 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
             "likelihood": {"y": y_likelihood, "z": z_likelihood},
         }
 
-    #context_model模型要在cup上测试。解码要求边解码边测试，所以更换算术编码器为range-coder，并且在编码时也需要串行操作。
+    # context_model模型要在cup上测试。解码要求边解码边测试，所以更换算术编码器为range-coder，并且在编码时也需要串行操作。
     def compress(self, x, filepath):
         if next(self.parameters()).device != torch.device('cpu'):
             warnings.warn("Inference on GPU is not recommended for the autoregressive "
-                "models (the entropy coder is run sequentially on CPU).")
+                          "models (the entropy coder is run sequentially on CPU).")
         # y.shape=[B,M,H,W]
         y = self.g_a(x)
         z = self.h_a(y)
         # 编解码z
         z_strings, z_minima, z_maxima = self.entropy_bottleneck.compress(z)
-        #z_hat = self.entropy_bottleneck.decompress(z_strings, z_minima, z_maxima, z.size())
+        # z_hat = self.entropy_bottleneck.decompress(z_strings, z_minima, z_maxima, z.size())
         z_hat = torch.round(z)
         y_q = self.gaussian_conditional.quantize(y, mode='quantize')
         # 编码y
         # params.shape=[B, 2M, H, W]
         params = self.h_s(z_hat)
-        s = 4  #y,z下采样倍数4
+        s = 4  # y,z下采样倍数4
         kernel_size = 5  # context prediction kernel size
         padding = (kernel_size - 1) // 2
 
@@ -383,19 +379,20 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
         # 在H和W这两个维度上做填充，上下左右各填充paddings，后面掩码卷积从第一个元素开始估计均值（不填充行和列的前后kernal_size/2个元素没法被估计）
         y_hat = F.pad(y, (padding, padding, padding, padding))
         # y.size(0) = B， test: default=1
-        y_minima, y_maxima = self.compress_serial(
-            y_hat,
-            params,
-            y_height,
-            y_width,
-            kernel_size,
-            padding,
-            filepath,
-         )
+        # y_minima, y_maxima = self.compress_serial(
+        #     y_hat,
+        #     params,
+        #     y_height,
+        #     y_width,
+        #     kernel_size,
+        #     padding,
+        #     filepath,
+        #  )
         y_minima, y_maxima = self.compress_pa(y_q, params, filepath)
-        return {"strings": z_strings, "shape": [y.shape, z.shape], "y_scope":[y_minima, y_maxima], "z_scope":[z_minima, z_maxima],
-        }
-    
+        return {"strings": z_strings, "shape": [y.shape, z.shape], "y_scope": [y_minima, y_maxima],
+                "z_scope": [z_minima, z_maxima],
+                }
+
     # 并行编码
     def compress_pa(self, y, params, filepath):
         y_minima = []
@@ -406,26 +403,25 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
             torch.cat((params, ctx_params), dim=1)
         )
         scales_hat, means_hat = gaussian_params.chunk(2, 1)
-        y_hat = self.gaussian_conditional.quantize( y,mode="quantize")
-        # print(self.context_prediction.weight*self.context_prediction.mask)
+        y_hat = self.gaussian_conditional.quantize(y, mode="quantize")
         encoder = RangeEncoder(filepath)
-        # print(f'ctx_p[:, :, 0, 1]:{ctx_params[:, :, 0, 1]}')
         for i in tqdm(range(height)):
             for j in range(width):
-                minima, maxima = self.gaussian_conditional.compress(y_hat[:, :, i:i+1, j:j+1], 
-                scales=scales_hat[:, :, i:i+1, j:j+1], means=means_hat[:, :, i:i+1, j:j+1],
-                model_name='JointAutoregressive',
-                encoder=encoder)
+                minima, maxima = self.gaussian_conditional.compress(y_hat[:, :, i:i + 1, j:j + 1],
+                                                                    scales=scales_hat[:, :, i:i + 1, j:j + 1],
+                                                                    means=means_hat[:, :, i:i + 1, j:j + 1],
+                                                                    model_name='JointAutoregressive',
+                                                                    encoder=encoder)
                 y_minima.append(minima)
                 y_maxima.append(maxima)
         encoder.close()
         return y_minima, y_maxima
-    
+
     # 串行编码
     def compress_serial(self, y_hat, params, height, width, kernel_size, padding, filepath):
         # 初始化一些参数
         # masked_weight.shape[2M, M, kernal_size, kernal_size]
-        masked_weight = self.context_prediction.weight*self.context_prediction.mask
+        masked_weight = self.context_prediction.weight * self.context_prediction.mask
         y_minima = []
         y_maxima = []
         # params.shape=[1, 2M, H, W] y_hat.shape=[1, M, H, W]
@@ -435,25 +431,24 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
         for i in tqdm(range(height)):
             for j in range(width):
                 # 每次取y_crop.shape=[1, M, kernal_size, kernal_size], kernal_size=5
-                y_crop = y_hat[:, :, i : i + kernel_size, j : j + kernel_size]
+                y_crop = y_hat[:, :, i: i + kernel_size, j: j + kernel_size]
                 # 掩码卷积，让被估计的元素处在卷积核中间位置
                 ctx_p = F.conv2d(
                     y_crop,
                     masked_weight,
                     bias=self.context_prediction.bias,
                 )
-                # print(f'ctx_p:{ctx_p.squeeze(3).squeeze(2)}')
                 # ctx_p.shape=[1, 2M, 1, 1], p.shape=[1, 2M, 1, 1]
-                p = params[:, :, i:i+1, j:j+1]
+                p = params[:, :, i:i + 1, j:j + 1]
                 gaussian_params = self.entropy_parameters(torch.cat((p, ctx_p), dim=1))
-                
+
                 scales_hat, means_hat = gaussian_params.chunk(2, 1)
                 # y_crop.shape [1, M, 1, 1]即通过上下文模型预测了在高和宽特定位置上所有通道的元素的均值
                 y_crop = y_crop[:, :, padding, padding].unsqueeze(2).unsqueeze(3)
 
                 # 对待编码元素每次只编码H,W某一特定位置上的所有通道
-                minima, maxima = self.gaussian_conditional.compress(y_crop, scales=scales_hat, means=means_hat, 
-                model_name='JointAutoregressive', encoder=encoder)
+                minima, maxima = self.gaussian_conditional.compress(y_crop, scales=scales_hat, means=means_hat,
+                                                                    model_name='JointAutoregressive', encoder=encoder)
                 y_minima.append(minima)
                 y_maxima.append(maxima)
         encoder.close()
@@ -467,14 +462,14 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
                 "models (the entropy coder is run sequentially on CPU)."
             )
 
-        z_hat = self.entropy_bottleneck.decompress(strings, z_scope[0], z_scope[1] ,shape[1])
+        z_hat = self.entropy_bottleneck.decompress(strings, z_scope[0], z_scope[1], shape[1])
         params = self.h_s(z_hat)
 
         kernel_size = 5  # context prediction kernel size
         padding = (kernel_size - 1) // 2
-        y_shape = shape[0] 
+        y_shape = shape[0]
         # y_hat.shape=[1, M, H+2*padding, W+2*padding]
-        y_hat = torch.zeros((1, y_shape[1], y_shape[2]+2*padding, y_shape[3]+2*padding), device=z_hat.device)
+        y_hat = torch.zeros((1, y_shape[1], y_shape[2] + 2 * padding, y_shape[3] + 2 * padding), device=z_hat.device)
         y_hat = self.decompress_serial(
             y_hat,
             params,
@@ -486,12 +481,11 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
         )
         # 去除为了使用掩码卷积而增加的padding
         y_hat = F.pad(y_hat, (-padding, -padding, -padding, -padding))
-        # print(f'y_hat[:,:,0,1]: {y_hat[:, :, 0, 1]}')
         x_hat = self.g_s(y_hat).clamp_(0, 1)
-        return x_hat 
+        return x_hat
 
     def decompress_serial(self, y_hat, params, shape, kernel_size, padding, y_scope, filepath):
-        masked_weight = self.context_prediction.weight*self.context_prediction.mask
+        masked_weight = self.context_prediction.weight * self.context_prediction.mask
         # print(masked_weight)
         y_minima = y_scope[0]
         y_maxima = y_scope[1]
@@ -501,66 +495,65 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
         decoder = RangeDecoder(filepath)
         for i in tqdm(range(height)):
             for j in range(width):
-                y_crop = y_hat[:, :, i: i+kernel_size, j: j+kernel_size]
+                y_crop = y_hat[:, :, i: i + kernel_size, j: j + kernel_size]
                 ctx_p = F.conv2d(
                     y_crop,
                     masked_weight,
-                    bias = self.context_prediction.bias,
+                    bias=self.context_prediction.bias,
                 )
-                # print(f'ctx_p:{ctx_p.squeeze(3).squeeze(2)}')
-                p = params[:, :, i:i+1, j:j+1]
+                p = params[:, :, i:i + 1, j:j + 1]
                 gaussian_params = self.entropy_parameters(torch.cat((p, ctx_p), dim=1))
                 scales_hat, means_hat = gaussian_params.chunk(2, 1)
                 channel_value = self.gaussian_conditional.decompress(
-                    strings=None, 
-                    minima=y_minima[i*width+j], maxima=y_maxima[i*width+j], shape=channel_shape, 
-                    scales=scales_hat, means=means_hat, 
+                    strings=None,
+                    minima=y_minima[i * width + j], maxima=y_maxima[i * width + j], shape=channel_shape,
+                    scales=scales_hat, means=means_hat,
                     decoder=decoder)
-                y_hat[:, :, i+padding, j+padding] = channel_value
-        decoder.close()   
+                y_hat[:, :, i + padding, j + padding] = channel_value
+        decoder.close()
         return y_hat
 
-    def encode(self,inputs,file_name,postfix=''):
+    def encode(self, inputs, file_name, postfix=''):
         """
         在compress的基础上调用熵编码器进一步封装额外的参数
         """
         # 由于range_coder编码需要文件名，首先创建编码y的文件
-        y_file_name = file_name+postfix+'_Fy.bin'
+        y_file_name = file_name + postfix + '_Fy.bin'
         with open(y_file_name, 'w'):
             pass
         out = self.compress(inputs, filepath=y_file_name)
         z_strings = out['strings']
-        y_shape,z_shape = out['shape']
-        z_minima,z_maxima = out['z_scope']
-        y_minima,y_maxima = out['y_scope']
-        with open(file_name+postfix+'_Fz.bin', 'wb') as fout:
+        y_shape, z_shape = out['shape']
+        z_minima, z_maxima = out['z_scope']
+        y_minima, y_maxima = out['y_scope']
+        with open(file_name + postfix + '_Fz.bin', 'wb') as fout:
             fout.write(z_strings)
 
-        with open(file_name+postfix+'_H.bin', 'wb') as fout:
+        with open(file_name + postfix + '_H.bin', 'wb') as fout:
             fout.write(np.array(z_shape, dtype=np.int32).tobytes())
             fout.write(np.array(len(z_minima), dtype=np.int8).tobytes())
-            #记录编码元素的属性：最大值，最小值，存储一个int8需要1Bytes
+            # 记录编码元素的属性：最大值，最小值，存储一个int8需要1Bytes
             fout.write(np.array(z_minima, dtype=np.int8).tobytes())
             fout.write(np.array(z_maxima, dtype=np.int8).tobytes())
 
             fout.write(np.array(y_shape, dtype=np.int32).tobytes())
             fout.write(np.array(len(y_minima), dtype=np.int16).tobytes())
-            #记录编码元素的属性：最大值，最小值，存储一个int16需要2Bytes
+            # 记录编码元素的属性：最大值，最小值，存储一个int16需要2Bytes
             fout.write(np.array(y_minima, dtype=np.int16).tobytes())
-            fout.write(np.array(y_maxima, dtype=np.int16).tobytes())  
-    
+            fout.write(np.array(y_maxima, dtype=np.int16).tobytes())
+
     def decode(self, file_name, postfix=''):
-        with open(file_name+postfix+'_Fz.bin', 'rb') as fin:
+        with open(file_name + postfix + '_Fz.bin', 'rb') as fin:
             z_strings = fin.read()
-        with open(file_name+postfix+'_H.bin', 'rb') as fin:
-            z_shape = np.frombuffer(fin.read(4*4), dtype=np.int32)
+        with open(file_name + postfix + '_H.bin', 'rb') as fin:
+            z_shape = np.frombuffer(fin.read(4 * 4), dtype=np.int32)
             z_len_minima = np.frombuffer(fin.read(1), dtype=np.int8)[0]
-            z_minima = np.frombuffer(fin.read(1*z_len_minima), dtype=np.int8)[0]
-            z_maxima = np.frombuffer(fin.read(1*z_len_minima), dtype=np.int8)[0]
-            y_shape = np.frombuffer(fin.read(4*4), dtype=np.int32)
+            z_minima = np.frombuffer(fin.read(1 * z_len_minima), dtype=np.int8)[0]
+            z_maxima = np.frombuffer(fin.read(1 * z_len_minima), dtype=np.int8)[0]
+            y_shape = np.frombuffer(fin.read(4 * 4), dtype=np.int32)
             y_len_minima = np.frombuffer(fin.read(2), dtype=np.int16)[0]
-            y_minima = np.frombuffer(fin.read(2*y_len_minima), dtype=np.int16)
-            y_maxima = np.frombuffer(fin.read(2*y_len_minima), dtype=np.int16)
+            y_minima = np.frombuffer(fin.read(2 * y_len_minima), dtype=np.int16)
+            y_maxima = np.frombuffer(fin.read(2 * y_len_minima), dtype=np.int16)
             # print(f'z_shape: {z_shape}')
             # print(f'z_len_minima: {z_len_minima}')
             # print(f'z_minima: {z_minima}')
@@ -568,12 +561,14 @@ class JointAutoregressiveHierarchicalPriors(nn.Module):
             # print(f'y_len_minima: {y_len_minima}')
             # print(f'y_minima: {y_minima}')
             # print(f'y_maxima: {y_maxima}')
-            y_file_name = file_name+postfix+'_Fy.bin'
+            y_file_name = file_name + postfix + '_Fy.bin'
             with open(y_file_name, 'rb'):
                 pass
-        x_hat = self.decompress(z_strings,[y_shape,z_shape],[y_minima,y_maxima],[z_minima,z_maxima], filepath=y_file_name)
+        x_hat = self.decompress(z_strings, [y_shape, z_shape], [y_minima, y_maxima], [z_minima, z_maxima],
+                                filepath=y_file_name)
         return x_hat
-    
+
+
 class CheckerboardContext(nn.Conv2d):
     """
     if kernel_size == (5, 5)
@@ -586,6 +581,7 @@ class CheckerboardContext(nn.Conv2d):
     0: non-anchor
     1: anchor
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -599,6 +595,7 @@ class CheckerboardContext(nn.Conv2d):
         out = super().forward(x)
 
         return out
+
 
 class CheckerboardAutogressive(JointAutoregressiveHierarchicalPriors):
     def __init__(self, N=192, M=192, **kwargs):
@@ -682,16 +679,15 @@ class CheckerboardAutogressive(JointAutoregressiveHierarchicalPriors):
     @torch.no_grad()
     def compress(self, x):
         """
-        if y[i, :, j, k] == 0 
+        if y[i, :, j, k] == 0
         then bpp = 0
         Not recommend
         """
         batch_size, channel, x_height, x_width = x.shape
         y = self.g_a(x)
         z = self.h_a(y)
-        self.entropy_bottleneck.to("cpu")
-        z_strings,z_minima,z_maxima = self.entropy_bottleneck.compress(z)
-        #z_hat = self.entropy_bottleneck.decompress(z_strings, z.size()[-2:])
+        z_strings, z_minima, z_maxima = self.entropy_bottleneck.compress(z)
+        # z_hat = self.entropy_bottleneck.decompress(z_strings, z.size()[-2:])
         z_hat = torch.round(z)
 
         params = self.h_s(z_hat)
@@ -709,11 +705,11 @@ class CheckerboardAutogressive(JointAutoregressiveHierarchicalPriors):
             torch.cat([ctx_params_anchor, params], dim=1)
         )
         scales_anchor, means_anchor = gaussian_params_anchor.chunk(2, 1)
-        anchor_strings,an_minima,an_maxima = self.gaussian_conditional.compress(anchor, 
-            scales_anchor, 
-            means_anchor, 
-            model_name='CheckerboardAutogressive')
-        anchor_quantized = self.gaussian_conditional.quantize(anchor,"quantize")
+        anchor_strings, an_minima, an_maxima = self.gaussian_conditional.compress(anchor,
+                                                                                  scales_anchor,
+                                                                                  means_anchor,
+                                                                                  model_name='CheckerboardAutogressive')
+        anchor_quantized = self.gaussian_conditional.quantize(anchor, "quantize")
 
         # compress non-anchor
         ctx_params_non_anchor = self.context_prediction(anchor_quantized)
@@ -721,34 +717,34 @@ class CheckerboardAutogressive(JointAutoregressiveHierarchicalPriors):
             torch.cat([ctx_params_non_anchor, params], dim=1)
         )
         scales_non_anchor, means_non_anchor = gaussian_params_non_anchor.chunk(2, 1)
-        non_anchor_strings,non_minima,non_maxima = self.gaussian_conditional.compress(non_anchor, 
-            scales_non_anchor, 
-            means=means_non_anchor, 
-            model_name='CheckerboardAutogressive'
-        )
+        non_anchor_strings, non_minima, non_maxima = self.gaussian_conditional.compress(non_anchor,
+                                                                                        scales_non_anchor,
+                                                                                        means=means_non_anchor,
+                                                                                        model_name='CheckerboardAutogressive'
+                                                                                        )
 
         return {
             "strings": [anchor_strings, non_anchor_strings, z_strings],
-            "shape": [y.shape,z.shape],
-            "anchor_scope":[an_minima,an_maxima],
-            "non_anchor_scope":[non_minima,non_maxima],
-            "z_scope":[z_minima,z_maxima]
+            "shape": [y.shape, z.shape],
+            "anchor_scope": [an_minima, an_maxima],
+            "non_anchor_scope": [non_minima, non_maxima],
+            "z_scope": [z_minima, z_maxima]
         }
 
     @torch.no_grad()
-    def decompress(self, strings, shape,anchor_scope,non_anchor_scope,z_scope):
+    def decompress(self, strings, shape, anchor_scope, non_anchor_scope, z_scope):
         """
-        if y[i, :, j, k] == 0 
+        if y[i, :, j, k] == 0
         then bpp = 0
         Not recommend
         """
         assert isinstance(strings, list) and len(strings) == 3
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        y_shape,z_shape = shape
+        y_shape, z_shape = shape
         an_minima, an_maxima = anchor_scope
         non_minima, non_maxima = non_anchor_scope
         z_minima, z_maxima = z_scope
-        z_hat = self.entropy_bottleneck.decompress(strings[2],z_minima, z_maxima,z_shape).to(device)
+        z_hat = self.entropy_bottleneck.decompress(strings[2], z_minima, z_maxima, z_shape).to(device)
         params = self.h_s(z_hat)
 
         batch_size, channel, z_height, z_width = z_hat.shape
@@ -759,14 +755,14 @@ class CheckerboardAutogressive(JointAutoregressiveHierarchicalPriors):
             torch.cat([ctx_params_anchor, params], dim=1)
         )
         scales_anchor, means_anchor = gaussian_params_anchor.chunk(2, 1)
-        anchor_quantized = self.gaussian_conditional.decompress(strings[0], 
-            an_minima, 
-            an_maxima, 
-            y_shape, 
-            scales_anchor, 
-            means_anchor, 
-            model_name='CheckerboardAutogressive'
-        ).to("cuda")
+        anchor_quantized = self.gaussian_conditional.decompress(strings[0],
+                                                                an_minima,
+                                                                an_maxima,
+                                                                y_shape,
+                                                                scales_anchor,
+                                                                means_anchor,
+                                                                model_name='CheckerboardAutogressive'
+                                                                ).to("cuda")
 
         # decompress non-anchor
         ctx_params_non_anchor = self.context_prediction(anchor_quantized)
@@ -774,76 +770,75 @@ class CheckerboardAutogressive(JointAutoregressiveHierarchicalPriors):
             torch.cat([ctx_params_non_anchor, params], dim=1)
         )
         scales_non_anchor, means_non_anchor = gaussian_params_non_anchor.chunk(2, 1)
-        non_anchor_quantized = self.gaussian_conditional.decompress(strings[1], 
-            non_minima, 
-            non_maxima, 
-            y_shape, 
-            scales_non_anchor, 
-            means_non_anchor, 
-            model_name='CheckerboardAutogressive'
-        ).to("cuda")
+        non_anchor_quantized = self.gaussian_conditional.decompress(strings[1],
+                                                                    non_minima,
+                                                                    non_maxima,
+                                                                    y_shape,
+                                                                    scales_non_anchor,
+                                                                    means_non_anchor,
+                                                                    model_name='CheckerboardAutogressive'
+                                                                    ).to("cuda")
 
         y_hat = anchor_quantized + non_anchor_quantized
         x_hat = self.g_s(y_hat)
 
         return x_hat
 
-    def encode(self,inputs,file_name,postfix=''):
+    def encode(self, inputs, file_name, postfix=''):
         """
         在compress的基础上调用熵编码器进一步封装额外的参数
         """
         out = self.compress(inputs)
-        anchor_strings,non_anchor_strings,z_strings = out['strings']
-        y_shape,z_shape = out['shape']
-        z_minima,z_maxima = out['z_scope']
-        an_minima,an_maxima = out['anchor_scope']
-        non_minima,non_maxima = out['non_anchor_scope']
-        
-        with open(file_name+postfix+'_Fz.bin', 'wb') as fout:
+        anchor_strings, non_anchor_strings, z_strings = out['strings']
+        y_shape, z_shape = out['shape']
+        z_minima, z_maxima = out['z_scope']
+        an_minima, an_maxima = out['anchor_scope']
+        non_minima, non_maxima = out['non_anchor_scope']
+
+        with open(file_name + postfix + '_Fz.bin', 'wb') as fout:
             fout.write(z_strings)
-        with open(file_name+postfix+'_Fanchor.bin', 'wb') as fout:
+        with open(file_name + postfix + '_Fanchor.bin', 'wb') as fout:
             fout.write(anchor_strings)
-        with open(file_name+postfix+'_Fnon_anchor.bin', 'wb') as fout:
+        with open(file_name + postfix + '_Fnon_anchor.bin', 'wb') as fout:
             fout.write(non_anchor_strings)
 
-        with open(file_name+postfix+'_H.bin', 'wb') as fout:
+        with open(file_name + postfix + '_H.bin', 'wb') as fout:
             fout.write(np.array(z_shape, dtype=np.int32).tobytes())
             fout.write(np.array(len(z_minima), dtype=np.int8).tobytes())
-            #记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
+            # 记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
             fout.write(np.array(z_minima, dtype=np.float32).tobytes())
             fout.write(np.array(z_maxima, dtype=np.float32).tobytes())
 
             fout.write(np.array(y_shape, dtype=np.int32).tobytes())
             fout.write(np.array(len(an_minima), dtype=np.int8).tobytes())
-            #记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
+            # 记录编码元素的属性：最大值，最小值，存储一个float32需要4Bytes
             fout.write(np.array(an_minima, dtype=np.float32).tobytes())
             fout.write(np.array(an_maxima, dtype=np.float32).tobytes())
             fout.write(np.array(non_minima, dtype=np.float32).tobytes())
             fout.write(np.array(non_maxima, dtype=np.float32).tobytes())
 
-
-    def decode(self,file_name,postfix=''):
-
-        with open(file_name+postfix+'_Fz.bin', 'rb') as fin:
+    def decode(self, file_name, postfix=''):
+        with open(file_name + postfix + '_Fz.bin', 'rb') as fin:
             z_strings = fin.read()
-        with open(file_name+postfix+'_H.bin', 'rb') as fin:
-            z_shape = np.frombuffer(fin.read(4*4), dtype=np.int32)
+        with open(file_name + postfix + '_H.bin', 'rb') as fin:
+            z_shape = np.frombuffer(fin.read(4 * 4), dtype=np.int32)
             z_len_minima = np.frombuffer(fin.read(1), dtype=np.int8)[0]
-            z_minima = np.frombuffer(fin.read(4*z_len_minima), dtype=np.float32)[0]
-            z_maxima = np.frombuffer(fin.read(4*z_len_minima), dtype=np.float32)[0]
+            z_minima = np.frombuffer(fin.read(4 * z_len_minima), dtype=np.float32)[0]
+            z_maxima = np.frombuffer(fin.read(4 * z_len_minima), dtype=np.float32)[0]
 
-            y_shape = np.frombuffer(fin.read(4*4), dtype=np.int32)
+            y_shape = np.frombuffer(fin.read(4 * 4), dtype=np.int32)
             y_len_minima = np.frombuffer(fin.read(1), dtype=np.int8)[0]
-            an_minima = np.frombuffer(fin.read(4*y_len_minima), dtype=np.float32)[0]
-            an_maxima = np.frombuffer(fin.read(4*y_len_minima), dtype=np.float32)[0]
-            non_minima = np.frombuffer(fin.read(4*y_len_minima), dtype=np.float32)[0]
-            non_maxima = np.frombuffer(fin.read(4*y_len_minima), dtype=np.float32)[0]
+            an_minima = np.frombuffer(fin.read(4 * y_len_minima), dtype=np.float32)[0]
+            an_maxima = np.frombuffer(fin.read(4 * y_len_minima), dtype=np.float32)[0]
+            non_minima = np.frombuffer(fin.read(4 * y_len_minima), dtype=np.float32)[0]
+            non_maxima = np.frombuffer(fin.read(4 * y_len_minima), dtype=np.float32)[0]
 
-        with open(file_name+postfix+'_Fanchor.bin', 'rb') as fin:
+        with open(file_name + postfix + '_Fanchor.bin', 'rb') as fin:
             anchor_strings = fin.read()
-        with open(file_name+postfix+'_Fnon_anchor.bin', 'rb') as fin:
+        with open(file_name + postfix + '_Fnon_anchor.bin', 'rb') as fin:
             non_anchor_strings = fin.read()
 
-        x_hat = self.decompress([anchor_strings,non_anchor_strings,z_strings],[y_shape,z_shape],[an_minima,an_maxima],[non_minima,non_maxima],[z_minima,z_maxima])
+        x_hat = self.decompress([anchor_strings, non_anchor_strings, z_strings], [y_shape, z_shape],
+                                [an_minima, an_maxima], [non_minima, non_maxima], [z_minima, z_maxima])
         return x_hat
 

--- a/test.py
+++ b/test.py
@@ -16,7 +16,6 @@ from statistics import plot_RDCurve, sum_dict, get_item, para_num
 
 # device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
-
 @torch.no_grad()
 def test(test_dataloader, ckptdir_list, outdir, resultdir, model_name='Factorized'):
     # load data

--- a/test.py
+++ b/test.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from data_utils import write_image, crop, cal_psnr
 from statistics import plot_RDCurve, sum_dict, get_item, para_num
 
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+# device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 
 @torch.no_grad()

--- a/test.py
+++ b/test.py
@@ -3,7 +3,7 @@ import numpy as np
 import os
 import pandas as pd
 import matplotlib.pyplot as plt
-from model import Factorized, Hyperprior, JointAutoregressiveHierarchicalPriors, CheckerboardAutogressive
+import model
 from data_loader import KodakDataset
 from torchvision import transforms
 from torch.utils.data import DataLoader
@@ -13,87 +13,69 @@ import time
 from tqdm import tqdm
 from data_utils import write_image, crop, cal_psnr
 from statistics import plot_RDCurve, sum_dict, get_item, para_num
+
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 
 @torch.no_grad()
 def test(test_dataloader, ckptdir_list, outdir, resultdir, model_name='Factorized'):
     # load data
-    start_time = time.time()
-
-    assert model_name in ["Factorized","Hyperprior","JointAutoregressiveHierarchicalPriors","CheckerboardAutogressive"]
+    assert model_name in ["Factorized", "Hyperprior", "JointAutoregressiveHierarchicalPriors",
+                          "CheckerboardAutogressive"]
     # 对于Factorized，前两个低码率点N=128，M=192，后两个高码率点N=192，M=320
     # 对于Hyperprior，前两个低码率点N=128，M=192，后两个高码率点N=192，M=320
     # 对于JointAutoregressiveHierarchicalPriors，前两个低码率点N=M=192，后两个高码率点N=192，M=320
     # 对于CheckerboardAutogressive，前两个低码率点N=M=192，后两个高码率点N=192，M=320
-    if model_name == 'JointAutoregressiveHierarchicalPriors' or not(torch.cuda.is_available()):
+    if model_name == 'JointAutoregressiveHierarchicalPriors' or not (torch.cuda.is_available()):
         device = 'cpu'
     elif torch.cuda.is_available():
         device = 'cuda'
     outdir_init = os.path.join(outdir, model_name)
     resultdir_init = os.path.join(resultdir, model_name)
-    
-    tag=1
-    lmbda=[0.0067,0.013,0.025,0.0483]
-    all_result=[]
+
+    tag = 1
+    lmbda = [0.0067, 0.013, 0.025, 0.0483]
+    all_result = []
     for i in range(len(ckptdir_list)):
         all_result.append({})
 
     for i, images in enumerate(tqdm(test_dataloader)):
-        #对测试图像分辨率做一个判断
+        # 对测试图像分辨率做一个判断
         images = crop(images)
         x = images.to(device)
         H, W = x.shape[-2:]
-        num_pixel = H*W
+        num_pixel = H * W
         one_pic_result = []
         for idx, ckptdir in enumerate(ckptdir_list):
-            #load model
-            if model_name == "Factorized":
-                if idx==2 or idx==3:
-                    model = Factorized(N=192, M=320).to(device)
-                else:
-                    model = Factorized().to(device)
-            
-            if model_name == "Hyperprior":
-                if idx==2 or idx==3:
-                    model = Hyperprior(entropy_bottleneck_channels=192,M=320).to(device)
-                else:
-                    model = Hyperprior(entropy_bottleneck_channels=128,M=192).to(device)
-            
-            if model_name == "JointAutoregressiveHierarchicalPriors":
-                if idx==2 or idx==3:
-                    model = JointAutoregressiveHierarchicalPriors(M=320).to(device)
-                else:
-                    model = JointAutoregressiveHierarchicalPriors(M=192).to(device)
-            
-            if model_name == "CheckerboardAutogressive":
-                if idx==2 or idx==3:
-                    model = CheckerboardAutogressive(N=192,M=320).to(device)
-                else:
-                    model = CheckerboardAutogressive(N=192,M=192).to(device)
-            
-            outdir=os.path.join(outdir_init,'lmbda_'+str(lmbda[idx]))
-            resultdir=os.path.join(resultdir_init,'lmbda_'+str(lmbda[idx]))
+            # load model
+            if idx <= 1:
+                model_ = getattr(model, args.model_name).to(device)
+            else:
+                model_ = getattr(model, args.model_name)(N=120, M=320).to(device)
+            # 部署熵模型到指定的设备
+            model_.entropy_bottleneck.to(args.entropy_device)
+            outdir = os.path.join(outdir_init, 'lmbda_' + str(lmbda[idx]))
+            resultdir = os.path.join(resultdir_init, 'lmbda_' + str(lmbda[idx]))
             if not os.path.exists(outdir): os.makedirs(outdir)
             if not os.path.exists(resultdir): os.makedirs(resultdir)
-                
-            print('='*10, tag, '='*10)
 
-            filename = os.path.join(outdir, str(i+1))
+            print('=' * 10, tag, '=' * 10)
+
+            filename = os.path.join(outdir, str(i + 1))
             print('output filename:\t', filename)
-            
+
             # load checkpoints
             assert os.path.exists(ckptdir)
             ckpt = torch.load(ckptdir)
             print('load checkpoint from \t', ckptdir)
             # 解决多卡训练出来的模型checkpoint的key都自动加上了'module'
-            model.load_state_dict({k.replace('module.',''):v for k,v in ckpt['model'].items()})
-            coder = Coder(model=model, filename=filename)
+            model_.load_state_dict({k.replace('module.', ''): v for k, v in ckpt['model'].items()})
+            coder = Coder(model=model_, filename=filename)
 
             # postfix: lmbda index
-            postfix_idx = '_lmbda'+str(lmbda[idx])
+            postfix_idx = '_lmbda' + str(lmbda[idx])
 
-             # encode
+            # encode
             start_time = time.time()
             _ = coder.encode(x, postfix=postfix_idx)
             print('Enc Time:\t', round(time.time() - start_time, 3), 's')
@@ -101,37 +83,37 @@ def test(test_dataloader, ckptdir_list, outdir, resultdir, model_name='Factorize
 
             # decode
             start_time = time.time()
-            x_dec = coder.decode(postfix=postfix_idx)  #从文件中读取数据然后解码，解码后对x_dec限定范围[0, 1]
+            x_dec = coder.decode(postfix=postfix_idx)  # 从文件中读取数据然后解码，解码后对x_dec限定范围[0, 1]
             x_dec = torch.clamp(x_dec, min=0.0, max=1.0)
             print('Dec Time:\t', round(time.time() - start_time, 3), 's')
             time_dec = round(time.time() - start_time, 3)
 
             # bitrate
             if args.model_name == "Factorized":
-                postfix_list = ['_F.bin','_H.bin']
+                postfix_list = ['_F.bin', '_H.bin']
             elif args.model_name == "CheckerboardAutogressive":
                 postfix_list = ['_Fanchor.bin', '_Fnon_anchor.bin', '_Fz.bin', '_H.bin']
             else:
-                postfix_list = ['_Fy.bin','_Fz.bin', '_H.bin']
+                postfix_list = ['_Fy.bin', '_Fz.bin', '_H.bin']
 
-            bits = np.array([os.path.getsize(filename + postfix_idx + postfix)*8 \
-                                    for postfix in postfix_list])
+            bits = np.array([os.path.getsize(filename + postfix_idx + postfix) * 8 \
+                             for postfix in postfix_list])
 
-            bpps = (bits/num_pixel).round(3)
-            print('num_pixel:',num_pixel)
-            print('bits:\t', sum(bits), '\nbpps:\t',  sum(bpps).round(3))
+            bpps = (bits / num_pixel).round(3)
+            print('num_pixel:', num_pixel)
+            print('bits:\t', sum(bits), '\nbpps:\t', sum(bpps).round(3))
 
-            #重建图片
+            # 重建图片
             start_time = time.time()
             # print(x_dec.detach().cpu().numpy().squeeze().shape)
-            write_image(filename+postfix_idx+'_dec.png', x_dec.detach().cpu().numpy().squeeze())
+            write_image(filename + postfix_idx + '_dec.png', x_dec.detach().cpu().numpy().squeeze())
             print('Write image Time:\t', round(time.time() - start_time, 3), 's')
-            #计算失真PSNR
-            psnr = cal_psnr(x, x_dec=x_dec) 
+            # 计算失真PSNR
+            psnr = cal_psnr(x, x_dec=x_dec)
             print(f'psnr:  {psnr}')
 
             # save results
-            results ={}
+            results = {}
             results["num_pixels"] = num_pixel
             results["bits"] = sum(bits).round(3)
             results["bpp"] = sum(bpps).round(3)
@@ -141,54 +123,55 @@ def test(test_dataloader, ckptdir_list, outdir, resultdir, model_name='Factorize
 
             one_pic_result.append(results)
 
-            #之前版本写入单个文件的操作
+            # 之前版本写入单个文件的操作
             '''all_results = results.copy()
             csv_name = os.path.join(resultdir, filename.split('/')[-1]+postfix_idx+'.csv')
-            
+
             with open(csv_name, 'w') as f:  
                 writer = csv.writer(f)
                 for k, v in results.items():
                     writer.writerow([k, v])
             print('Wrile results to: \t', csv_name)'''
-           
-        tag=tag+1
+
+        tag = tag + 1
 
         all_result = sum_dict(all_result, one_pic_result, pic_num=24, ckpt_num=len(ckptdir_list))
 
-
     if not os.path.exists("./statistics"): os.makedirs("./statistics")
-    
-    df = pd.DataFrame(all_result, index=[0.0067,0.013,0.025,0.0483])
-    csv_name = "./statistics/"+model_name+".csv"
-    df.to_csv(csv_name, index_label=True)    
+
+    df = pd.DataFrame(all_result, index=[0.0067, 0.013, 0.025, 0.0483])
+    csv_name = "./statistics/" + model_name + ".csv"
+    df.to_csv(csv_name, index_label=True)
     print('Wrile results to: \t', csv_name)
 
     return all_result
-        
+
 
 if __name__ == '__main__':
     import argparse
+
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--outdir", default='./output')
     parser.add_argument("--resultdir", default='./results')
     parser.add_argument("--dataset_path", default='/data1/liubj/kodak')
     parser.add_argument("--test_batch_size", default=1)
-    parser.add_argument("--model_name",default='Factorized',help="other implemntation: 'Hyperprior', 'JointAutoregressiveHierarchicalPriors', 'CheckerboardAutogressive'")
-    parser.add_argument("--load_model_epoch",default=199,help="加载模型所对应的epoch")
-    parser.add_argument("--entropy_device",default='cpu',help="熵模型的device, 'cuda' or 'cpu'")
+    parser.add_argument("--model_name", default='Factorized',
+                        help="other implemntation: 'Hyperprior', 'JointAutoregressiveHierarchicalPriors', 'CheckerboardAutogressive'")
+    parser.add_argument("--load_model_epoch", default=199, help="加载模型所对应的epoch")
+    parser.add_argument("--entropy_device", default='cpu', help="熵模型的device, 'cuda' or 'cpu'")
     args = parser.parse_args()
-    
-    ckptdir_list = ['./ckpts/'+args.model_name+'/epoch_'+ str(args.load_model_epoch) + '_lmbda_0.0067' + '.pth', 
-                    './ckpts/'+args.model_name+'/epoch_'+ str(args.load_model_epoch) + '_lmbda_0.013' + '.pth',
-                    './ckpts/'+args.model_name+'/epoch_'+ str(args.load_model_epoch) + '_lmbda_0.025' + '.pth',
-                    './ckpts/'+args.model_name+'/epoch_'+ str(args.load_model_epoch) + '_lmbda_0.0483' + '.pth']
+
+    ckptdir_list = ['./ckpts/' + args.model_name + '/epoch_' + str(args.load_model_epoch) + '_lmbda_0.0067' + '.pth',
+                    './ckpts/' + args.model_name + '/epoch_' + str(args.load_model_epoch) + '_lmbda_0.013' + '.pth',
+                    './ckpts/' + args.model_name + '/epoch_' + str(args.load_model_epoch) + '_lmbda_0.025' + '.pth',
+                    './ckpts/' + args.model_name + '/epoch_' + str(args.load_model_epoch) + '_lmbda_0.0483' + '.pth']
 
     test_transforms = transforms.Compose(
         [transforms.ToTensor()]
     )
 
-    test_dataset = KodakDataset(args.dataset_path, test_transforms) 
+    test_dataset = KodakDataset(args.dataset_path, test_transforms)
     samplerC = SequentialSampler(test_dataset)
     test_dataloader = DataLoader(
         test_dataset,
@@ -200,18 +183,16 @@ if __name__ == '__main__':
 
     all_result = test(test_dataloader, ckptdir_list, args.outdir, args.resultdir, args.model_name)
 
-    
     fig, ax = plt.subplots(figsize=(7, 4))
-    plt.plot(np.array(get_item(all_result, "bpp", ckpt_num=len(ckptdir_list))), 
-        np.array(get_item(all_result, "psnr", ckpt_num=len(ckptdir_list))), label="D1", marker='x', color='red')
-    
+    plt.plot(np.array(get_item(all_result, "bpp", ckpt_num=len(ckptdir_list))),
+             np.array(get_item(all_result, "psnr", ckpt_num=len(ckptdir_list))), label="D1", marker='x', color='red')
+
     plt.title(args.model_name)
     plt.xlabel('bpp')
     plt.ylabel('PSNR')
     plt.grid(ls='-.')
     plt.legend(loc='lower right')
-    fig.savefig(os.path.join("./statistics", args.model_name+'.jpg'))
-
+    fig.savefig(os.path.join("./statistics", args.model_name + '.jpg'))
 
     plot_RDCurve()
 

--- a/train.py
+++ b/train.py
@@ -1,16 +1,17 @@
 from ast import parse
-import  os, argparse
-from data_loader import VimeoDataset,KodakDataset
-from model import Factorized, Hyperprior, JointAutoregressiveHierarchicalPriors, CheckerboardAutogressive
+import os, argparse
+from data_loader import VimeoDataset, KodakDataset
+import model
 from trainer import Trainer
 from torchvision import transforms
 from torch.utils.data import DataLoader
 from loss import RateDistortionLoss
 import torch
 
+
 def parse_args():
     parser = argparse.ArgumentParser(
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument("--dataset", default='/data1/liubj/vimeo_1')
     parser.add_argument("--lmbda", type=float, default=1e-2, help="weights for distoration.")
@@ -21,16 +22,19 @@ def parse_args():
     parser.add_argument("--test_dataset", default='/data1/liubj/Kodak24')
     parser.add_argument("--test_batch_size", type=int, default=24)
     parser.add_argument("--epoch", type=int, default=250)
-    parser.add_argument("--check_time", type=float, default=10,  help='frequency for recording state (min).') 
-    parser.add_argument("--prefix", type=str, default='FactorizedPrior', help="prefix of checkpoints/logger, etc. e.g. FactorizedPrior, HyperPrior")
-    parser.add_argument("--model_name",default='Factorized',help="other implemntation: 'Hyperprior', 'JointAutoregressiveHierarchicalPriors', 'CheckerboardAutogressive'")
-    parser.add_argument("--exp_version", default=0, type=int, help='target an experimental version to avoid overwritting')
-    parser.add_argument("--load_model_epoch",default=None,type=int)
+    parser.add_argument("--check_time", type=float, default=10, help='frequency for recording state (min).')
+    parser.add_argument("--prefix", type=str, default='FactorizedPrior',
+                        help="prefix of checkpoints/logger, etc. e.g. FactorizedPrior, HyperPrior")
+    parser.add_argument("--model_name", default='Factorized',
+                        help="other implemntation: 'Hyperprior', 'JointAutoregressiveHierarchicalPriors', 'CheckerboardAutogressive'")
+    parser.add_argument("--exp_version", default=0, type=int,
+                        help='target an experimental version to avoid overwritting')
     # if you want to use 1 gpu, just --gpu_id '0', if 3 gpus are needed, pass --gpu_id '0 1 2' for example
     parser.add_argument("--gpu_id", type=str, default="0", help="GPU(s) to use, space delimited")
     parser.add_argument("--code_rate", type=str, default="low", help="choice of code_rate: 'low' or 'high'")
     args = parser.parse_args()
     return args
+
 
 class TrainingConfig():
     def __init__(self, logdir, ckptdir, init_ckpt, lmbda, lr, check_time, device):
@@ -41,16 +45,18 @@ class TrainingConfig():
         self.init_ckpt = init_ckpt
         self.lmbda = lmbda
         self.lr = lr
-        self.check_time=check_time
+        self.check_time = check_time
         self.device = device
 
-def set_optimizer(model, lr):
-        params_lr_list = []
-        for module_name in model._modules.keys():
-            params_lr_list.append({"params":model._modules[module_name].parameters(), 'lr':lr})
-        optimizer = torch.optim.Adam(params_lr_list)
 
-        return optimizer
+def set_optimizer(model, lr):
+    params_lr_list = []
+    for module_name in model._modules.keys():
+        params_lr_list.append({"params": model._modules[module_name].parameters(), 'lr': lr})
+    optimizer = torch.optim.Adam(params_lr_list)
+
+    return optimizer
+
 
 if __name__ == '__main__':
     # log
@@ -59,54 +65,28 @@ if __name__ == '__main__':
     # we select the first gpu as the main device
     device = torch.device("cuda:%d" % args.gpu_id[0]) if torch.cuda.is_available() else torch.device("cpu")
     training_config = TrainingConfig(
-                            logdir=os.path.join('./logs', args.prefix, str(args.exp_version)), 
-                            ckptdir=os.path.join('./ckpts', args.prefix, str(args.exp_version)),
-                            init_ckpt=args.init_ckpt,
-                            lmbda=args.lmbda,
-                            lr=args.lr, 
-                            check_time=args.check_time,
-                            device=device)
+        logdir=os.path.join('./logs', args.prefix, str(args.exp_version)),
+        ckptdir=os.path.join('./ckpts', args.prefix, str(args.exp_version)),
+        init_ckpt=args.init_ckpt,
+        lmbda=args.lmbda,
+        lr=args.lr,
+        check_time=args.check_time,
+        device=device)
     # model
-    if args.model_name == "Factorized":
-        # 对于低码率，N=128,M=192
-        # 对于高码率，N=192,M=320
-        if args.code_rate == "low":
-            model = Factorized()
-        elif args.code_rate == "high":
-            model = Factorized(N=192, M=320)
-    elif args.model_name == "Hyperprior":
-        # 对于低码率，N=128,M=192
-        # 对于高码率，N=192,M=320
-        if args.code_rate == "low":
-            model = Factorized()
-        elif args.code_rate == "high":
-            model = Factorized(N=192, M=320)
-    elif args.model_name == "JointAutoregressiveHierarchicalPriors":
-        # 对于低码率，N=192,M=192
-        # 对于高码率，N=192,M=320
-        if args.code_rate == "low":
-            model = JointAutoregressiveHierarchicalPriors()
-        elif args.code_rate == "high":
-            model = JointAutoregressiveHierarchicalPriors(M=320)
-    elif args.model_name == "CheckerboardAutogressive":
-        # 对于低码率，N=192,M=192
-        # 对于高码率，N=192,M=320
-        if args.code_rate == "low":
-            model = CheckerboardAutogressive()
-        elif args.code_rate == "high":
-            model = CheckerboardAutogressive(M=320)
-    
-    if args.load_model_epoch is not None:
-        pretrained_model_path = './ckpts/'+args.prefix+'/epoch_'+ str(args.load_model_epoch) +'.pth'
-        ckpt = torch.load(pretrained_model_path)
-        model.load_state_dict(ckpt["model"])
-    if len(args.gpu_id) >1:
-        model = torch.nn.DataParallel(model, device_ids=args.gpu_id, dim=0)
+    assert args.model_name in ['Factorized', 'Hyperprior', 'JointAutoregressiveHierarchicalPriors',
+                               'CheckerboardAutogressive']
+    if args.code_rate == 'low':
+        model_ = getattr(model, args.model_name)
+    elif args.code_rate == 'high':
+        model_ = getattr(model, args.model_name)(N=120, M=320)
+
+    if len(args.gpu_id) > 1:
+        model_ = torch.nn.DataParallel(model_, device_ids=args.gpu_id, dim=0)
 
     criterion = RateDistortionLoss(lmbda=args.lmbda)
-    # trainer    
-    trainer = Trainer(config=training_config, model=model,criterion=criterion)
-    
+    # trainer
+    trainer = Trainer(config=training_config, model=model_, criterion=criterion)
+
     # dataset
     train_transforms = transforms.Compose(
         [transforms.RandomCrop(256), transforms.ToTensor()]
@@ -116,8 +96,8 @@ if __name__ == '__main__':
         [transforms.CenterCrop(256), transforms.ToTensor()]
     )
 
-    train_dataset = VimeoDataset(args.dataset, 'train', train_transforms) 
-    test_dataset = KodakDataset(args.test_dataset, test_transforms) 
+    train_dataset = VimeoDataset(args.dataset, 'train', train_transforms)
+    test_dataset = KodakDataset(args.test_dataset, test_transforms)
     train_dataloader = DataLoader(
         train_dataset,
         batch_size=args.batch_size,
@@ -136,10 +116,10 @@ if __name__ == '__main__':
     )
 
     # optimizer setting
-    optimizer = set_optimizer(model.to(training_config.device), args.lr)
+    optimizer = set_optimizer(model_.to(training_config.device), args.lr)
     # lr update: Reduce learning rate when loss has stopped reducing.
     lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, "min", factor=0.5, verbose=True)
     # training
     for epoch in range(0, args.epoch):
-        loss=trainer.train(train_dataloader, optimizer)
+        loss = trainer.train(train_dataloader, optimizer)
         lr_scheduler.step(loss)

--- a/train.py
+++ b/train.py
@@ -57,7 +57,6 @@ def set_optimizer(model, lr):
 
     return optimizer
 
-
 if __name__ == '__main__':
     # log
     args = parse_args()

--- a/train.py
+++ b/train.py
@@ -54,7 +54,6 @@ def set_optimizer(model, lr):
     for module_name in model._modules.keys():
         params_lr_list.append({"params": model._modules[module_name].parameters(), 'lr': lr})
     optimizer = torch.optim.Adam(params_lr_list)
-
     return optimizer
 
 if __name__ == '__main__':

--- a/trainer.py
+++ b/trainer.py
@@ -5,7 +5,6 @@ from thop import clever_format
 import numpy as np
 import torch
 from torch.utils.tensorboard import SummaryWriter
-# device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 class Trainer():
     def __init__(self, config, model, criterion):
@@ -38,7 +37,7 @@ class Trainer():
     def load_state_dict(self):
         """selectively load model
         """
-        if self.config.init_ckpt=='':
+        if self.config.init_ckpt == '':
             self.logger.info('Random initialization.')
         else:
             ckpt = torch.load(self.config.init_ckpt)
@@ -47,30 +46,22 @@ class Trainer():
         return
 
     def save_model(self):
-        torch.save({'model': self.model.state_dict()}, 
+        torch.save({'model': self.model.state_dict()},
             os.path.join(self.config.ckptdir, 'epoch_' + str(self.epoch) + '.pth'))
         return
-
-    # def set_optimizer(self):
-    #     params_lr_list = []
-    #     for module_name in self.model._modules.keys():
-    #         params_lr_list.append({"params":self.model._modules[module_name].parameters(), 'lr':self.config.lr})
-    #     optimizer = torch.optim.Adam(params_lr_list, betas=(0.9, 0.999), weight_decay=1e-4)
-
-    #     return optimizer
 
     @torch.no_grad()
     def record(self, main_tag, global_step):
         # print record
         self.logger.info('='*10+main_tag + ' Epoch ' + str(self.epoch) + ' Step: ' + str(global_step))
-        for k, v in self.record_set.items(): 
-            self.record_set[k]=np.mean(np.array(v), axis=0)
-        for k, v in self.record_set.items(): 
-            self.logger.info(k+': '+str(np.round(v, 4).tolist()))   
+        for k, v in self.record_set.items():
+            self.record_set[k] = np.mean(np.array(v), axis=0)
+        for k, v in self.record_set.items():
+            self.logger.info(k+': '+str(np.round(v, 4).tolist()))
         # return zero
-        for k in self.record_set.keys(): 
-            self.record_set[k] = []  
-        return 
+        for k in self.record_set.keys():
+            self.record_set[k] = []
+        return
 
     @torch.no_grad()
     def test(self, dataloader, main_tag='Test'):
@@ -85,11 +76,11 @@ class Trainer():
             self.record_set['sum_loss'].append(out_criterion['loss'].item())
             torch.cuda.empty_cache()# empty cache.
         self.record(main_tag=main_tag, global_step=self.epoch)
-        return 
+        return
 
     def train(self, dataloader, optimizer, clip_max_norm=1.0):
         self.logger.info('='*40+'\n'+'Training Epoch: ' + str(self.epoch))
-        self.logger.info('lmbda:' + str(round(self.config.lmbda,2)))
+        self.logger.info('lmbda:' + str(round(self.config.lmbda, 2)))
         self.logger.info('LR:' + str(np.round([params['lr'] for params in optimizer.param_groups], 6).tolist()))
         # dataloader
         self.logger.info('Training Files length:' + str(len(dataloader)))
@@ -116,10 +107,9 @@ class Trainer():
                 self.record_set['sum_loss'].append(out_criterion['loss'].item())
                 self.writer.add_scalars("train", out_criterion, global_step = self.iteration)
                 # add_scaler 传递变量
-                if (time.time() - start_time) > self.config.check_time*60:
+                if self.iteration % 500 == 0:
                     self.record(main_tag='Train', global_step=self.epoch*len(dataloader)+batch_step)
                     self.save_model()
-                    start_time = time.time()
             torch.cuda.empty_cache()# empty cache.
             self.iteration += 1
 

--- a/trainer.py
+++ b/trainer.py
@@ -18,11 +18,11 @@ class Trainer():
         self.epoch = 0
         self.iteration = 0
         self.writer = SummaryWriter(config.logdir)
-        self.record_set = {'bpp':[],'mse':[],'sum_loss':[]}
+        self.record_set = {'bpp': [], 'mse': [], 'sum_loss':[]}
 
     def getlogger(self, logdir):
         logger = logging.getLogger(__name__)
-        logger.setLevel(level = logging.INFO)
+        logger.setLevel(level=logging.INFO)
         handler = logging.FileHandler(os.path.join(logdir, 'log.txt'))
         handler.setLevel(logging.INFO)
         formatter = logging.Formatter('%(asctime)s: %(message)s', datefmt='%m/%d %H:%M:%S')

--- a/trainer.py
+++ b/trainer.py
@@ -84,7 +84,6 @@ class Trainer():
         self.logger.info('LR:' + str(np.round([params['lr'] for params in optimizer.param_groups], 6).tolist()))
         # dataloader
         self.logger.info('Training Files length:' + str(len(dataloader)))
-        start_time = time.time()
         for batch_step, images in enumerate(tqdm(dataloader)):
             images = images.to(self.device)
             optimizer.zero_grad()


### PR DESCRIPTION
修改了train.py和test.py中模型加载的代码，减少冗余;
使用了test.py中传入的entropy_devcie参数;
修改了entropybottleneck只能在cpu上运行的问题，即删除了decompress函数里239行的to('cpu');
删除了model中的compress和decompress方法中将熵模型强制放在cpu运行的代码；
删除了一些多余的测试代码性质的注释。